### PR TITLE
3 fix EF5 graph legends

### DIFF
--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -27,7 +27,7 @@ output$EF5_trendPlot_measure_ouput <- renderUI({
     "EF5_trendPlot_measure",
     label = "Select measure to visualise:",
     choices = EF5_trend_measures,
-    selected = "Percentage 'Did Not Attend' appointmnets"
+    selected = "Percentage 'Did Not Attend' appointments"
     )
 })
 

--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -69,35 +69,41 @@ output$EF5_trendPlot <- renderPlotly({
            color = hb_name,   # Have to do this outside so that the legends shows and so that there aren't 3 legends
            shape = hb_name) +
        # Adding PHS accessibility colour scheme for lines
-       scale_color_discrete_phs(name = "NHS Health Board", 
+       scale_color_discrete_phs(name = "", 
                                 palette = "main-blues",
                                 labels = ~ stringr::str_wrap(.x, width = 15)) +
-       scale_linetype_manual(name = "NHS Health Board", 
+       scale_linetype_manual(name = "",
                              values = c("solid", "dashed", "solid", "dashed"),
                              labels = ~ stringr::str_wrap(.x, width = 15)) +
-       scale_shape_manual(name = "NHS Health Board", 
+       scale_shape_manual(name = "", 
                           values = c("circle", "square", "triangle-up", "triangle-down"), 
                           labels = ~ stringr::str_wrap(.x, width = 15)) +
        theme_classic() +                         # I normally use bw but will see what this looks like (de-clutters graph background)
        theme(
+         # Set legend position to bottom and remove legend title
+         legend.position = "bottom", 
+         # legend.title = element_blank(),
+         legend.text = element_text(size = 8, 
+                                    colour = "black"),
          # panel.grid.major.x = element_line(),  # Shows vertical grid lines 
-             panel.grid.major.y = element_line(),  # Shows horizontal grid lines 
-             axis.title.x = element_text(size = 12,
-                                         color = "black",
-                                         face = "bold"),
-             axis.text.x = element_text(angle = 25),
-             axis.title.y = element_text(size = 12,
-                                         color = "black",
-                                         face = "bold"),
-             legend.text = element_text(size = 8, 
-                                        colour = "black"), 
-             legend.title = element_text(size = 9, 
-                                         colour = "black", 
-                                         face = "bold")) +  
+         panel.grid.major.y = element_line(),  # Shows horizontal grid lines 
+         axis.title.x = element_text(size = 12,
+                                     color = "black",
+                                     face = "bold"),
+         axis.text.x = element_text(angle = 25),
+         axis.title.y = element_text(size = 12,
+                                     color = "black",
+                                     face = "bold")
+          
+         # legend.title = element_text(size = 9, 
+         #                             colour = "black", 
+         #                             face = "bold")
+         ) +  
        labs(x = "\n Calendar Quarter", 
             y = paste0(str_wrap(input$EF5_trendPlot_measure, width = 30), "\n \n")) +
        scale_y_continuous(expand = c(0, 0),   # Ensures y axis starts from zero (important for Orkney and Shetland HBs which are all zero)
                           limits = c(0, (max(EF5_trendPlot_data()$value) + 0.5*max(EF5_trendPlot_data()$value)))) 
+     # change to 1.2*max
      
    })
             
@@ -105,7 +111,9 @@ output$EF5_trendPlot <- renderPlotly({
    ### Run ggplot graph through plotly ----
    
    ggplotly(EF5_trendPlot_graph(),
-            tooltip = "text") %>%        # uses text set up in ggplot aes above. 
+            tooltip = "text") %>%        # uses text set up in ggplot aes above.
+     # Needed to set the legend below the graph with ggplotly
+     layout(legend = list(orientation = "h", x = 0.0, y = -0.4)) %>% 
    ### Remove unnecessary buttons from the modebar ----
    config(displayModeBar = TRUE,
           modeBarButtonsToRemove = bttn_remove,

--- a/modules/indicators/EF5_ui.R
+++ b/modules/indicators/EF5_ui.R
@@ -53,7 +53,7 @@ tabItem(tabName = "EF5_tab",
           fluidRow(
              box(width = 12,
                  plotlyOutput("EF5_trendPlot",
-                              # height = "50vh",
+                              height = 600,
                               width = "100%"))
           ),
           


### PR DESCRIPTION
Both EF5 graphs have been changed from ggplot + ggplotly to a ggplot graph which has fixed the ability to add graph titles as well as allowed for full HB names to be visible in the legends.

Also applied a fix for EF5 trend plot initial measure not displaying the measure defined as selected in the code.