### PR TITLE
44 graph na note and replacing 0s

### DIFF
--- a/modules/indicators/E1_server.R
+++ b/modules/indicators/E1_server.R
@@ -65,97 +65,96 @@ output$E1_graph1_selected_areaName <- renderText({
 
 ## Create the discharges line chart ----
 
-   ### Render plotly ----
-
 output$E1_plot1 <- renderPlotly({
    
-   plot_ly(data = E1_plot1_Data(), 
-           
-           x = ~fyear, 
-           y = ~dd_bed_days, 
-           color = ~area_name, 
-           
-           # Tooltip text - Health board of treatment OR Council area of residence
-           text = if_else(E1_plot1_Data()$area_type == "Health board", 
-                          paste0("Financial year: ",
-                                 E1_plot1_Data()$fyear,
-                                 "<br>",
-                                 "Health board of treatment: ",
-                                 E1_plot1_Data()$area_name,
-                                 "<br>",
-                                 "Total number of days: ",
-                                 E1_plot1_Data()$dd_bed_days, 
-                                 "<br>",
-                                 "Rate per 1,000 population: ",
-                                 E1_plot1_Data()$rate_per_1000_population),
-                          paste0("Financial year: ",
-                                 E1_plot1_Data()$fyear,
-                                 "<br>",
-                                 "Council area of residence: ",
-                                 E1_plot1_Data()$area_name,
-                                 "<br>",
-                                 "Total number of days: ",
-                                 E1_plot1_Data()$dd_bed_days, 
-                                 "<br>",
-                                 "Rate per 1,000 population: ",
-                                 E1_plot1_Data()$rate_per_1000_population)),
-           hoverinfo = "text",
-           
-           # Line aesthetics: 
-           type = 'scatter',
-           mode = 'lines+markers', 
-           line = list(width = 3), 
-           colors = c("#3F3685", "#9B4393", "#0078D4", "#1E7F84"),
-           linetype = ~area_name, 
-           linetypes = c("solid", "dashed", "solid", "dashed"), 
-           symbol = ~area_name,
-           symbols = c("circle", "square", "triangle-up", "triangle-down"),
-           marker = list(size = 12),
-           # Size of graph:
-           height = 600,
-           # Legend info:
-           name = ~str_wrap(area_name, 15)) %>%
+   # Assign to an object so we can add Orkney/Shetland data title note afterwards
+   E1_plot1_plotly <- plot_ly(data = E1_plot1_Data(), 
+                    
+                    x = ~fyear, 
+                    y = ~dd_bed_days, 
+                    color = ~area_name, 
+                    
+                    # Tooltip text - Health board of treatment OR Council area of residence
+                    text = if_else(E1_plot1_Data()$area_type == "Health board", 
+                                   paste0("Financial year: ",
+                                          E1_plot1_Data()$fyear,
+                                          "<br>",
+                                          "Health board of treatment: ",
+                                          E1_plot1_Data()$area_name,
+                                          "<br>",
+                                          "Total number of days: ",
+                                          E1_plot1_Data()$dd_bed_days, 
+                                          "<br>",
+                                          "Rate per 1,000 population: ",
+                                          E1_plot1_Data()$rate_per_1000_population),
+                                   paste0("Financial year: ",
+                                          E1_plot1_Data()$fyear,
+                                          "<br>",
+                                          "Council area of residence: ",
+                                          E1_plot1_Data()$area_name,
+                                          "<br>",
+                                          "Total number of days: ",
+                                          E1_plot1_Data()$dd_bed_days, 
+                                          "<br>",
+                                          "Rate per 1,000 population: ",
+                                          E1_plot1_Data()$rate_per_1000_population)),
+                    hoverinfo = "text",
+                    
+                    # Line aesthetics: 
+                    type = 'scatter',
+                    mode = 'lines+markers', 
+                    line = list(width = 3), 
+                    colors = c("#3F3685", "#9B4393", "#0078D4", "#1E7F84"),
+                    linetype = ~area_name, 
+                    linetypes = c("solid", "dashed", "solid", "dashed"), 
+                    symbol = ~area_name,
+                    symbols = c("circle", "square", "triangle-up", "triangle-down"),
+                    marker = list(size = 12),
+                    # Size of graph:
+                    height = 600,
+                    # Legend info:
+                    name = ~str_wrap(area_name, 15)) %>%
+               
+               layout(# graph title is in a box above the graph and Orkney/Shetland 
+                      # reminder title is below this code. 
+                      yaxis = list(exponentformat = "none",
+                                   separatethousands = TRUE,  
+                                   range = c(0, max(E1_plot1_Data()$dd_bed_days) * 110 / 100), 
+                                   
+                                   # Wrap the y axis title in spaces so it doesn't cover the tick labels.
+                                   title = paste0(c(rep("&nbsp;", 20),
+                                                    print("Total Number of Days"), 
+                                                    rep("&nbsp;", 20),
+                                                    rep("\n&nbsp;", 3)),
+                                                  collapse = ""),#),
+                                   showline = TRUE, 
+                                   ticks = "outside"),
+                      
+                      xaxis = list(tickangle = -45,            # Diagonal x-axis ticks
+                                   title = paste0(c(rep("&nbsp;", 20),
+                                                    "<br>",
+                                                    "<br>",
+                                                    "Financial Year",
+                                                    rep("&nbsp;", 20),
+                                                    rep("\n&nbsp;", 3)),
+                                                  collapse = ""),
+                                   showline = TRUE, 
+                                   ticks = "outside"),
+                      
+                      # Set the graph margins:
+                      margin = list(l = 90, r = 60, b = 170, t = 90),  
+                      
+                      # Set the font sizes:
+                      font = list(size = 13),
+                      
+                      # Add a legend & make the legend background and border white:            
+                      showlegend = TRUE,
+                      legend = list(x = 1, 
+                                    y = 0.8, 
+                                    bgcolor = 'rgba(255, 255, 255, 0)', 
+                                    bordercolor = 'rgba(255, 255, 255, 0)'))%>%
       
-      layout(yaxis = list(exponentformat = "none",
-                          separatethousands = TRUE,  
-                          range = c(0, max(E1_plot1_Data()$dd_bed_days) * 110 / 100), 
-                          
-                          
-                          # Wrap the y axis title in spaces so it doesn't cover the tick labels.
-                          title = paste0(c(rep("&nbsp;", 20),
-                                           print("Total Number of Days"), 
-                                           rep("&nbsp;", 20),
-                                           rep("\n&nbsp;", 3)),
-                                         collapse = ""),#),
-                          showline = TRUE, 
-                          ticks = "outside"
-      ),
-      
-      xaxis = list(tickangle = -45,                    # Diagonal x-axis ticks
-                   title = paste0(c(rep("&nbsp;", 20),
-                                    "<br>",
-                                    "<br>",
-                                    "Financial Year",
-                                    rep("&nbsp;", 20),
-                                    rep("\n&nbsp;", 3)),
-                                  collapse = ""),
-                   showline = TRUE, 
-                   ticks = "outside"),
-      
-      # Set the graph margins:
-      margin = list(l = 90, r = 60, b = 170, t = 90),  
-      
-      # Set the font sizes:
-      font = list(size = 13),
-      
-      # Add a legend & make the legend background and border white:            
-      showlegend = TRUE,
-      legend = list(x = 1, 
-                    y = 0.8, 
-                    bgcolor = 'rgba(255, 255, 255, 0)', 
-                    bordercolor = 'rgba(255, 255, 255, 0)')) %>%
-      
-      # Remove any buttons we don't need from the modebar.
+      ### Remove any buttons we don't need from the modebar ----
       config(displayModeBar = TRUE,
              modeBarButtonsToRemove = list('select2d', 'lasso2d', 
                                            # 'zoomIn2d', 'zoomOut2d', 'autoScale2d', 
@@ -164,15 +163,38 @@ output$E1_plot1 <- renderPlotly({
                                            'hoverClosestCartesian'), 
              displaylogo = F, 
              editable = F)
-   
-   
+  
+     ### Add Orkney/ Shetland reminder title ---- 
+  
+         if #("NHS Orkney" %in% input$E1_plot1_areaName &    # Not necessary
+        #     "NHS Shetland" %in% input$E1_plot1_areaName) {
+        #    E1_plot1_plotly <- E1_plot1_plotly %>% 
+        #       layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+        #    } else if 
+             ("NHS Orkney" %in% input$E1_plot1_areaName) {
+              E1_plot1_plotly <- E1_plot1_plotly %>%
+                 layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+              } else if ("NHS Shetland" %in% input$E1_plot1_areaName) {
+                 E1_plot1_plotly <- E1_plot1_plotly %>% 
+                    layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+                 } else {
+                    E1_plot1_plotly <- E1_plot1_plotly %>% layout(title = NULL)
+                    }
+  
+  
+  ### Return the plot ----
+  E1_plot1_plotly
+  
+      
 })
 
 
 ## Table below graph 1 ----
  
  output$E1_1_table <- renderDataTable({
-   datatable(E1_plot1_Data(),
+   datatable(E1_plot1_Data() %>% 
+                # Add "NA" as a value to table on dashboard:
+                mutate(across(dd_bed_days:rate_per_1000_population, ~replace(., is.na(.), "NA"))),
              style = 'bootstrap',
              class = 'table-bordered table-condensed',
              rownames = FALSE,
@@ -216,17 +238,28 @@ output$E1_plot2_year_output <- renderUI({
 })
 
 ## Selecting appropriate data for graph 2 ---- 
-
+# Taking Orkney and Shetland out of the graph, adding ordering, adding colours for graph
 E1_plot2_Data <- reactive({
    E1_data %>%
       select(fyear, area_type, area_name, dd_bed_days, rate_per_1000_population) %>%
-      filter(area_type == "Health board") %>% 
+     # filter(area_type == "Health board") %>% 
+      filter(area_type == "Health board" &
+                (area_type == "Health board" &
+                    (area_name != "NHS Orkney" & area_name !="NHS Shetland"))) %>%
       filter(fyear %in% input$E1_plot2_year) %>% 
       mutate(area_name = fct_reorder(area_name, rate_per_1000_population)) %>%    # for ordering by most to least bed days
       mutate(to_highlight = if_else(area_name == "NHS Scotland",                  # for highlighting NHS Scotland 
                                     "#3F3685", "#0078D4"))                       # changed from "yes" and "no" so that these colours 
 })                                                             # appear on the graph and don't have a legend using "marker = list(color... )"
 
+## Selecting appropriate data for table 2 ---- 
+E1_plot2_Data_for_table <- reactive({
+   E1_data %>%
+      select(fyear, area_type, area_name, dd_bed_days, rate_per_1000_population) %>%
+      filter(area_type == "Health board")  %>%
+      filter(fyear %in% input$E1_plot2_year) 
+   })
+   
 ## Reactive graph 2 title ---- 
 
 output$E1_graph2_selected_fyear <- renderUI({
@@ -298,8 +331,9 @@ output$E1_plot2 <- renderPlotly({
 ## Graph 2 data table ----
 
 output$E1_2_table <- renderDataTable({
-  datatable(E1_plot2_Data() %>% 
-               select(!c("to_highlight")),
+  datatable(E1_plot2_Data_for_table() %>% 
+               # Add "NA" as a value to table on dashboard:
+               mutate(across(dd_bed_days:rate_per_1000_population, ~replace(., is.na(.), "NA"))),
             style = 'bootstrap',
             class = 'table-bordered table-condensed',
             rownames = FALSE,
@@ -315,12 +349,10 @@ output$E1_2_table <- renderDataTable({
 ## Table 2 download button ---- 
 # allows user to download selected data in .csv format
 
-
 output$E1_2_table_download <- downloadHandler(
   filename = 'E1 - Bed days per 1000 population when patient ready for discharge for chosen year.csv',
   content = function(file) {
-    write.table(E1_plot2_Data()%>% 
-                   select(!"to_highlight"),
+    write.table(E1_plot2_Data_for_table(),
                 file,
                 #Remove row numbers as the .csv file already has row numbers.
                 row.names = FALSE,

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -418,8 +418,9 @@ output$S2_plot3_title <- renderUI({
       ### Render plotly ----
       
       output$S2_plot3 <- renderPlotly({
-         
-         plot_ly(data = S2_plot3_data_for_graph(),
+       
+       # Assign to an object so we can add Orkney/Shetland data title note afterwards
+         S2_plot3_plotly <- plot_ly(data = S2_plot3_data_for_graph(),
                  
                  x = ~year_months, 
                  y = ~number, 
@@ -452,7 +453,9 @@ output$S2_plot3_title <- renderUI({
                  # Legend info:
                  name = ~str_wrap(total_or_followed_up, 15)) %>%
             
-            layout(yaxis = list(exponentformat = "none",
+            layout(# graph title is in a box above the graph and Orkney/Shetland 
+               # reminder title is below this code. 
+                   yaxis = list(exponentformat = "none",
                                 separatethousands = TRUE,  
                                 range = c(0, max(S2_plot3_data_for_graph()$number) * 110 / 100), 
                                 # Wrap the y axis title in spaces so it doesn't cover the tick labels:
@@ -512,74 +515,33 @@ output$S2_plot3_title <- renderUI({
                    displaylogo = F, 
                    editable = F)
          
-      })
+         ### Add Orkney/ Shetland / Lanarkshire titles ---- 
          
-    
-   ### Old ggplot code ----      
-      #    
-      #    S2_plot3_graph <- reactive({
-      #       ggplot(S2_plot3_data_for_graph(),
-      #              aes(x = year_months,
-      #                  y = number,
-      #                  text = paste0("Calendar quarter: ", S2_plot3_data_for_graph()$year_months,        # for tooltip in ggplotly - shows values on hover
-      #                                "<br>",
-      #                                "NHS health board: ", S2_plot3_data_for_graph()$nhs_health_board,
-      #                                "<br>",
-      # 
-      #                                case_when(total_or_followed_up == "Number of patients followed up" ~
-      #                                             paste0("Number of patients followed up: ", S2_plot3_data_for_graph()$number),
-      #                                          total_or_followed_up == "Total number of discharged inpatients" ~
-      #                                             paste0("Total number of inpatients discharged: ", S2_plot3_data_for_graph()$number),
-      #                                          TRUE ~ "No Data")))) +
-      #          geom_line() + 
-      #          geom_point(size = 2.5) + 
-      #          aes(group = total_or_followed_up,  # Have to do this outside so that the legends shows and so that there aren't 3 legends
-      #              linetype = total_or_followed_up, 
-      #              color = total_or_followed_up, 
-      #              shape = total_or_followed_up) + 
-      #          scale_color_discrete_phs(name = unique(S2_plot3_data_for_graph()$nhs_health_board), 
-      #                                   palette = "main-blues",
-      #                                   labels = ~ stringr::str_wrap(.x, width = 15)) +
-      #          scale_linetype_manual(name = unique(S2_plot3_data_for_graph()$nhs_health_board),
-      #                                values = c("solid", "dashed", "solid", "dashed"),
-      #                                labels = ~ stringr::str_wrap(.x, width = 15)) +
-      #          scale_shape_manual(name = unique(S2_plot3_data_for_graph()$nhs_health_board), 
-      #                             values = c("circle", "square", "triangle-up", "triangle-down"),
-      #                             labels = ~ stringr::str_wrap(.x, width = 15)) +
-      #           # geom_text(aes(label = if_else(is.na(number),
-      #           #                               "NA", "")), # "value" shown on graph is "NA" for NAs, no text for HBs with values
-      #           #           na.rm = FALSE,
-      #           #           nudge_y = 2,
-      #           #           size = 4) +
-      #          theme_classic() +
-      #          theme(panel.grid.major.x = element_line(),
-      #                panel.grid.major.y = element_line(),
-      #                axis.title.x = element_text(size = 12,
-      #                                            color = "black",
-      #                                            face = "bold"),
-      #                axis.text.x = element_text(angle = 25)) + 
-      #          labs(x = paste0("Calendar Quarter"),
-      #               y = "Number of Patients") +
-      #          scale_y_continuous(#na.value = 0,   # for placing "NA" but this isn't working nicely (brings graph line down to wherever you place it)
-      #                             n.breaks = 10,
-      #                             expand = c(0,0)) +  # remove spacing between dates on x axis and 0  on y axis
-      #          coord_cartesian(ylim = c(0, (max(S2_plot3_data_for_graph()$number) + 
-      #                                          (0.1*max(S2_plot3_data_for_graph()$number)))), 
-      #                          expand = TRUE)
-      #         # ylim = c(0, (max(S2_plot3_data_for_graph()$number) + (0.1*max(S2_plot3_data_for_graph()$number)))) # having issues with NAs not allowing axis to extend 
-      #    })
-      #    
-      #    ### Run graph 3 through plotly
-      #    ggplotly(S2_plot3_graph(),
-      #             tooltip = "text") %>%     # uses text set up in ggplot aes above.
-      #     #  layout(legend = list(orientation = 'h')) %>%   # After discussion, we don't want this - moves legend to bottom
-      #       ### Remove unnecessary buttons from the modebar
-      #    config(displayModeBar = TRUE,
-      #           modeBarButtonsToRemove = bttn_remove,
-      #           displaylogo = F, editable = F)
-      #    
-      # })
-
+         if ("NHS Lanarkshire" %in% input$S2_Plot3_hbName & 
+             ("NHS Orkney" %in% input$S2_Plot3_hbName |    
+              "NHS Shetland" %in% input$S2_Plot3_hbName)) {
+            S2_plot3_plotly <- S2_plot3_plotly %>% 
+               layout(title = paste0("Data is not available for this selection - NHS Lanarkshire.", 
+                                     "<br>", 
+                                     "NHS Orkney & NHS Shetland values are included in NHS Grampian data."))
+         } else if ("NHS Orkney" %in% input$S2_Plot3_hbName) {
+            S2_plot3_plotly <- S2_plot3_plotly %>%
+               layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+         } else if ("NHS Shetland" %in% input$S2_Plot3_hbName) {
+            S2_plot3_plotly <- S2_plot3_plotly %>% 
+               layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+         } else if ("NHS Lanarkshire" %in% input$S2_Plot3_hbName) {
+            S2_plot3_plotly <- S2_plot3_plotly %>% 
+               layout(title = "Data is not available for this selection - NHS Lanarkshire")
+         }else {
+            S2_plot3_plotly <- S2_plot3_plotly %>% layout(title = NULL)
+         }
+         
+         ### Return the plot ---- 
+         S2_plot3_plotly
+         
+      })
+ 
 
    ## Table for graph 3 ----
    

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -39,7 +39,8 @@ S2_trendPlot_data <- reactive({
 output$S2_trendPlot <- renderPlotly({ 
   
   
-  plot_ly(data = S2_trendPlot_data(),
+   # Assign to an object so we can add Orkney/Shetland data title note afterwards
+   S2_plot1_plotly <- plot_ly(data = S2_trendPlot_data(),
           
           x = ~year_months, y = ~percentage_followed_up, color = ~nhs_health_board,
           
@@ -70,17 +71,8 @@ output$S2_trendPlot <- renderPlotly({
           # Legend info
           name = ~str_wrap(nhs_health_board, 15)) %>%
     
-    layout(title = str_wrap(paste0(c(rep("&nbsp;", 10),
-                                     "<b>",
-                                     "Percentage of psychiatric inpatients followed up by community mental health services ",
-                                     "within 7 calendar days of being discharged.", 
-                                     # "<em>",
-                                     "2022-2024 calendar quarters for your selected health board(s)", 
-                                     # "</em>", 
-                                     "</b>",
-                                  rep("&nbsp;", 10),
-                                  rep("\n&nbsp;", 3))
-                                  ), 54),
+    layout(# graph title is in a box above the graph and Orkney/Shetland 
+       # reminder title is below this code. 
            yaxis = list(
              # Wrap the y axis title in spaces so it doesn't cover the tick labels.
              title = #list(
@@ -132,6 +124,32 @@ output$S2_trendPlot <- renderPlotly({
                                          'hoverCompareCartesian', 
                                          'hoverClosestCartesian'), 
            displaylogo = F, editable = F)
+   
+   ### Add Orkney/ Shetland / Lanarkshire titles ---- 
+   
+   if ("NHS Lanarkshire" %in% input$S2_trendPlot_hbName & 
+       ("NHS Orkney" %in% input$S2_trendPlot_hbName |    
+        "NHS Shetland" %in% input$S2_trendPlot_hbName)) {
+      S2_plot1_plotly <- S2_plot1_plotly %>% 
+          layout(title = paste0("Data is not available for this selection - NHS Lanarkshire.", 
+                                "<br>", 
+                                "NHS Orkney & NHS Shetland values are included in NHS Grampian data."))
+       } else if ("NHS Orkney" %in% input$S2_trendPlot_hbName) {
+      S2_plot1_plotly <- S2_plot1_plotly %>%
+         layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+   } else if ("NHS Shetland" %in% input$S2_trendPlot_hbName) {
+      S2_plot1_plotly <- S2_plot1_plotly %>% 
+         layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+   } else if ("NHS Lanarkshire" %in% input$S2_trendPlot_hbName) {
+      S2_plot1_plotly <- S2_plot1_plotly %>% 
+         layout(title = "Data is not available for this selection - NHS Lanarkshire")
+   }else {
+      S2_plot1_plotly <- S2_plot1_plotly %>% layout(title = NULL)
+   }
+   
+   
+   ### Return the plot ----
+   S2_plot1_plotly
 })
 
 ## Table below graph 1 ----

--- a/modules/indicators/S2_ui.R
+++ b/modules/indicators/S2_ui.R
@@ -216,7 +216,7 @@ tabItem(tabName = "S2_tab",
                  p("Board returns for Oct-Dec 2024 have been received from: 
                  NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
                  NHS Forth Valley, NHS Grampian, NHS Greater Glasgow & Clyde, 
-                 NHS Highland, NHS Lanarkshire, NHS Lothian, NHS Tayside and 
+                 NHS Highland, NHS Lothian, NHS Tayside and 
                  NHS Western Isles."), 
                  p("Data from all hospital psychiatric inpatient wards and from 
                  all community mental health services of all care groups and 

--- a/modules/indicators/S5_server.R
+++ b/modules/indicators/S5_server.R
@@ -42,7 +42,8 @@ S5_trendPlot_data <- reactive({
 
 output$S5_trendPlot <- renderPlotly({ 
   
-   plot_ly(data = S5_trendPlot_data(), 
+   # Assign to an object so we can add Orkney/Shetland data title note afterwards
+   S5_plot1_plotly <- plot_ly(data = S5_trendPlot_data(), 
            
            x = ~year_months, 
            y = ~incidents_per_1000_bed_days, 
@@ -74,7 +75,9 @@ output$S5_trendPlot <- renderPlotly({
            # Legend info:
            name = ~str_wrap(nhs_health_board, 15)) %>%
       
-      layout(yaxis = list(exponentformat = "none",
+      layout(# graph title is in a box above the graph and Orkney/Shetland 
+             # reminder title is below this code. 
+             yaxis = list(exponentformat = "none",
                           separatethousands = TRUE,  # it's per 1,000 so do we need to do this? 
                           range = c(0, max(S5_trendPlot_data()$incidents_per_1000_bed_days, na.rm = TRUE) * 110 / 100), 
                         
@@ -125,6 +128,21 @@ output$S5_trendPlot <- renderPlotly({
              displaylogo = F, 
              editable = F)
     
+      ### Add Orkney/ Shetland reminder title ---- 
+      
+      if ("NHS Orkney" %in% input$S5_trendPlot_hbName) {
+         S5_plot1_plotly <- S5_plot1_plotly %>%
+            layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+      } else if ("NHS Shetland" %in% input$S5_trendPlot_hbName) {
+         S5_plot1_plotly <- S5_plot1_plotly %>% 
+            layout(title = "NHS Orkney & NHS Shetland values are included in NHS Grampian data")
+      } else {
+         S5_plot1_plotly <- S5_plot1_plotly %>% layout(title = NULL)
+      }
+      
+      
+      ### Return the plot ----
+   S5_plot1_plotly  
    
 })
 


### PR DESCRIPTION
S2 
- Orkney and Shetland show as NA on tables and a message appears on the line graph to say their data is included in Grampian's data if a user selects either/ both of them. They are not shown in the bar chart but are included in the table.
- Lanarkshire - line graphs show a message to say data is not available if the user selects them. Bar chart shows Lanarkshire as "NA". Tables shows "NA". They are also taken out of the "data returned by:" section in the info at the bottom of the page. 

S5
- Orkney and Shetland show as NA on tables and a message appears on the line graph to say their data is included in Grampian's data if a user selects either/ both of them. They are not shown in the bar chart but are included in the table.

EF4 
- Dumfries and Galloway were showing "0" for one year but are now showing as "NA" in table, and with a gap in the graph. 

E1 
- Orkney and Shetland now showing as "NA" instead of as 0. Graphs and tables are as in S2. 