### PR TITLE
45 scothub title overlap

### DIFF
--- a/modules/sidebar_ui.R
+++ b/modules/sidebar_ui.R
@@ -42,8 +42,7 @@ sidebarMenu(
   br(),
   ## Effective Tabs ----           
   menuItem("Effective :"),
-  menuItem("E1 - Delayed Discharge", tabName = "E1_tab", icon = icon("bar-chart"), 
-     badgeLabel = "Revision", badgeColor = "light-blue"),
+  menuItem("E1 - Delayed Discharge", tabName = "E1_tab", icon = icon("bar-chart")),
           
   br(),
   ## Efficient Tabs ----           
@@ -51,8 +50,7 @@ sidebarMenu(
   menuItem("EF 1 - Emergency Bed Days", tabName = "EF1_tab", icon = icon("image")),
   menuItem("EF 2 - Readmissions", tabName = "EF2_tab", icon = icon("image")),
   menuItem("EF 3 - Psychiatric Beds", tabName = "EF3_tab", icon = icon("image")),
-  menuItem("EF 4 - Mental Health Spend", tabName = "EF4_tab", icon = icon("bar-chart"),
-           badgeLabel = "Updated", badgeColor = "orange"),
+  menuItem("EF 4 - Mental Health Spend", tabName = "EF4_tab", icon = icon("bar-chart")),
   menuItem("EF 5 - Community DNA", tabName = "EF5_tab", icon = icon("bar-chart"), 
            badgeLabel = "New", badgeColor = "green"),
             

--- a/www/stylesheet.css
+++ b/www/stylesheet.css
@@ -66,25 +66,14 @@ h3 {
 .navpageButton{
   background-color: #9B4393; /* button colour - phs-magenta */
   color: #ECEBF3; /* text colour --phs-purple-10*/
-  border: 4px rounded ;
-  /*word-wrap: normal; /* tell css to wrap the text in buttons */
-  /*white-space: normal; /* required for text wrapping to work */
-  /*align: right;*/
 }
 
 
 /* Download button under tables */
 .tableDownloadButton { 
   background-color: #3F3685; 
-  color: #FFFFFF;
+  color: #ECEBF3;
 } 
-
-
-/* Main header*/
-/*.main-header .navbar {
-  background-color: #ECEBF3; /* Header colour */
- /* color: #3F3685; /* Header text colour */
-/*}*/
 
 
 /* [Dashboard Skin] */
@@ -136,6 +125,7 @@ h3 {
   border-color: #C5C3DA;
 }
 
+
 /* Header */
 .box-header{
   background-color: #E9F2F3; /* Header colour */
@@ -143,29 +133,32 @@ h3 {
   /*font-weight: bold;*/
   word-wrap: normal; /* tell css to wrap the text in buttons */
   white-space: normal; /* required for text wrapping to work */
-  height: 90px; /* Specifying height of Header area */
+  /*height: 90px;*/ /* Specifying height of Header area */
   border: thin solid #C5C3DA;
 }
 
-/* Box Header Text */
-.box-header h3{
-  /* */
-  font-size: 36px; 
-  font-weight: bold; 
-  /*line-height: 3; Doesn't seem to change anything */
+/*
+#scot_hub .box-header{
+  whitespace: nowrap;
+  overflow:hidden;
+  text-overflow: ellipsis;
+ height: 300px;
 }
+*/
 
-.box-title h3{
+/* Box Text */
+
+.box-title {
   font-size: 36px;
   font-weight: bold;
-  text-align: center;
+  /*text-align: center;*/
 }
+
 .box-body{
   color: #3F3685;
   font-size: 20px; /* Change this to your desired font size */
   font-weight: bold;
-  /*word-wrap: normal; /* tell css to wrap the text in buttons */
-  /*white-space: normal; /* required for text wrapping to work */
+  
 }
 
 


### PR DESCRIPTION
Fixed title overlap by adjusting css so that boxes auto adjust for the amount of text in the title section. Unfortunately auto adjust and height attributes are mutually exclusive so a minimum height can't be set while auto adjust is in play.

Fixed the css stylesheet by deleting some unclosed comments which were breaking the script.

Updated the sidebar to remove the updated and revision tags.