### PR TITLE
48 axis formatting   all graphs

### DIFF
--- a/data_preparation.R
+++ b/data_preparation.R
@@ -24,7 +24,14 @@ months_function <- function(dat, var) {
 ## E1 ----
 E1_data <- read.csv("data/E1.csv") %>% 
   rename(dd_bed_days = delayed_discharge_bed_days,
-         fyear = financial_year)
+         fyear = financial_year) %>% 
+   # have fyears as a factor in case there are any NAs in the data 
+   mutate(fyear = factor(fyear, levels = 
+                            c("2016/17", "2017/18", "2018/19", 
+                              "2019/20", "2020/21", "2021/22", 
+                              "2022/23", "2023/24"))) %>% 
+                              # , "2024/25")))
+   arrange(fyear)
 
 E1_area_types <- E1_data %>% 
   distinct(area_type) %>% pull(area_type)
@@ -34,19 +41,27 @@ E1_fyear <- E1_data %>%
    distinct(fyear) %>% 
    pull(fyear)
 
-## EQ1 ----
-EQ1_data <- read.csv("data/EQ1.csv") %>% 
-   mutate(Year = as.character(Year))
 
-unique_area_types <- EQ1_data %>% 
+
+## EQ1 ----
+EQ1_data <- read.csv("data/EQ1.csv") 
+
+# Years need to be factored so they appear on graph even if there's no data 
+# This will update automatically but the graph ranges may need to be added to
+EQ1_distinct_years <- EQ1_data %>% distinct(Year) %>% pull
+
+EQ1_data <- EQ1_data %>% 
+   mutate(Year = factor(Year, levels = EQ1_distinct_years))
+                         
+
+EQ1_unique_area_types <- EQ1_data %>% 
   distinct(area_type) %>% pull(area_type)
 
 # For EQ1 plot 2:
 EQ1_reformatted_data <- read.csv("data/EQ1_Reformatted.csv")%>% 
-   mutate(Rate = round(Rate))        # because values are e.g. "3158.23942548425913"
+   mutate(Rate = round(Rate)) %>%   # because values are e.g. "3158.23942548425913"
+   mutate(Year = factor(Year, levels = EQ1_distinct_years))
 
-unique_area_types_reformatted <- EQ1_reformatted_data %>% 
-  distinct(area_type) %>% pull(area_type)
 
 # Create data for EQ1 bar plot (need one column for each bar trace)
 EQ1_plot2_data <- EQ1_reformatted_data %>% 
@@ -56,6 +71,8 @@ EQ1_plot2_data <- EQ1_reformatted_data %>%
          genpop_rate = "General Population Rate")
 
 
+
+
 ## EF4 ----
 EF4_data <- read.csv("data/EF4.csv") %>% 
   select(fyear, hb_name, measure, value) %>% 
@@ -63,7 +80,15 @@ EF4_data <- read.csv("data/EF4.csv") %>%
    mutate(measure = if_else(measure == "Mental Health Expenditure (%)", 
                             "Mental Health Expenditure", measure)) %>% 
    mutate(measure = if_else(measure == "CAMHS Expenditure (%)", 
-                            "CAMHS Expenditure", measure))
+                            "CAMHS Expenditure", measure)) %>% 
+   # Years need to be factored so they appear on graph even if there's no data - add each update
+   mutate(fyear = factor(fyear, levels = 
+                            c("2012/13", "2013/14", "2014/15", 
+                              "2015/16", "2016/17", "2017/18", 
+                              "2018/19", "2019/20", "2020/21", 
+                              "2021/22", "2022/23", "2023/24"))) %>% 
+                              # , "2024/25")))
+   arrange(hb_name, fyear, measure)
 
 EF4_fyear <- EF4_data %>% 
   distinct(fyear) %>% pull(fyear)

--- a/modules/indicators/E1_server.R
+++ b/modules/indicators/E1_server.R
@@ -119,8 +119,7 @@ output$E1_plot1 <- renderPlotly({
                       # reminder title is below this code. 
                       yaxis = list(exponentformat = "none",
                                    separatethousands = TRUE,  
-                                   range = c(0, max(E1_plot1_Data()$dd_bed_days) * 110 / 100), 
-                                   
+                                   range = list(0, max(E1_plot1_Data()$dd_bed_days, na.rm = TRUE) * 1.2), 
                                    # Wrap the y axis title in spaces so it doesn't cover the tick labels.
                                    title = paste0(c(rep("&nbsp;", 20),
                                                     print("Total Number of Days"), 
@@ -311,6 +310,8 @@ output$E1_plot2 <- renderPlotly({
                                            rep("&nbsp;", 20),
                                            rep("\n&nbsp;", 3)),
                                          collapse = ""),
+                          range = list(0, max(E1_data$rate_per_1000_population, na.rm = TRUE) * 1.1),
+                          # Re: range - all time highest figure so that quarters can be compared visually when clicking through them
                           showline = TRUE, 
                           ticks = "outside"),
              # Set graph margins:

--- a/modules/indicators/EF4_server.R
+++ b/modules/indicators/EF4_server.R
@@ -102,17 +102,15 @@ EF4_trendPlot_data <- reactive({
             # Legend info:
             name = ~str_wrap(measure, 15)) %>%
        
-       layout(yaxis = list(exponentformat = "none",
-                           #separatethousands = TRUE,  
-                           range = c(0, max(EF4_trendPlot_data()$value) * 110 / 100), 
-                           
-                           
+       layout(yaxis = list(exponentformat = "none", 
+                           # Range: "*1.2) is good for the highest tick for most HBs without going to high
+                           range = c(0, max(EF4_trendPlot_data()$value, na.rm = TRUE) * 1.2), 
                            # Wrap the y axis title in spaces so it doesn't cover the tick labels.
                            title = paste0(c(rep("&nbsp;", 20),
                                             print("Percentage (%)"), 
                                             rep("&nbsp;", 20),
                                             rep("\n&nbsp;", 3)),
-                                          collapse = ""),#),
+                                          collapse = ""),
                            showline = TRUE, 
                            ticks = "outside"),
               
@@ -124,6 +122,13 @@ EF4_trendPlot_data <- reactive({
                                             rep("&nbsp;", 20),
                                             rep("\n&nbsp;", 3)),
                                           collapse = ""),
+                           # For range - we have 12 years up to 2023/24 - this will 
+                           # need to be updated when new years are added to the code. 
+                           # Edit will be to add 1 to the second figure with each new 
+                           # year (i.e. it will be (-0.5, 12.5) in next update)
+                           # Starting at -0.5 and ending at 11.5 gives much nicer 
+                           # spacing on the axis than "0, 12"
+                           range = list(-0.5, 11.5), 
                            showline = TRUE, 
                            ticks = "outside"),
               

--- a/modules/indicators/EF4_server.R
+++ b/modules/indicators/EF4_server.R
@@ -49,8 +49,8 @@ output$EF4_trendPlot_title <- renderUI({
   
   # HB section
   req(input$EF4_trendPlot_hbName)
-  paste0("Percentage of ", input$EF4_trendPlot_hbName, "'s Total Spend Attributed to ", 
-         EF4_measure_text, ", by Financial Year")
+  paste0("Percentage of ", input$EF4_trendPlot_hbName, "'s total spend attributed to ", 
+         EF4_measure_text, ", by financial year")
   
 })
 

--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -105,6 +105,13 @@ output$EF5_trendPlot <- renderPlotly({
                                             rep("&nbsp;", 20),
                                             rep("\n&nbsp;", 3)),
                                           collapse = ""),
+                           # For range - we have 12 quarters up to Dec 2024 - this will 
+                           # need to be updated when new quarters are added to the code. 
+                           # Edit will be to add 1 to the second figure with each new 
+                           # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
+                           # Starting at -0.5 and ending at 11.5 gives much nicer 
+                           # spacing on the axis than "0, 12"
+                           range = list(-0.5, 11.5), 
                            showline = TRUE, 
                            ticks = "outside"),
               

--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -34,7 +34,8 @@ output$EF5_trendPlot_measure_ouput <- renderUI({
 ## Create text for graph title ui section ----
 output$EF5_trendPlot_selected_measure <- renderUI({
   req(input$EF5_trendPlot_measure)
-  paste0(input$EF5_trendPlot_measure, " in selected health board(s), by calendar quarter:")
+  paste0(input$EF5_trendPlot_measure, " for mental health based community 
+         appointmnents in selected health board(s), by calendar quarter")
 })
 
 ## Graph Data Reactive ---- 
@@ -191,8 +192,7 @@ output$EF5_measurePlot_selected_hb <- renderUI({
   req(input$EF5_measurePlot_hbName)
   paste0("Number of 'Did Not Attend' appointments Vs Total number of appointments ", 
          "for mental health based community appointmnents in ",
-         input$EF5_measurePlot_hbName,
-         ":")
+         input$EF5_measurePlot_hbName)
 })
 
 ## Graph measure Data Reactive ----

--- a/modules/indicators/EQ1_server.R
+++ b/modules/indicators/EQ1_server.R
@@ -6,7 +6,7 @@ output$EQ1_plot1_areaType_output <- renderUI({
   shinyWidgets::pickerInput(
     "EQ1_plot1_areaType",
     label = "Select type of geography:",
-    choices = unique_area_types,
+    choices = EQ1_unique_area_types,
     selected = "Health board"
   )
 })
@@ -103,7 +103,7 @@ output$EQ1_plot1 <- renderPlotly({
       yaxis = list(
         exponentformat = "none",
         separatethousands = TRUE,
-        range = c(0, max(EQ1_plot1_Data()$risk_ratio, na.rm = TRUE) * 110 / 100), 
+        range = list(0, max(EQ1_plot1_Data()$risk_ratio, na.rm = TRUE) * 110 / 100), 
         font = list(size = 13),
         # Wrap the y axis title in spaces so it doesn't cover the tick labels
         title = paste0(c(rep("&nbsp;", 20),
@@ -123,6 +123,13 @@ output$EQ1_plot1 <- renderPlotly({
                                     rep("&nbsp;", 20),
                                     rep("\n&nbsp;", 3)),
                                   collapse = ""),
+                   # For range - we have 5 years up to 2022 - this will 
+                   # need to be updated when new years are added to the code. 
+                   # Edit will be to add 1 to the second figure with each new 
+                   # quarter (i.e. it will be (-0.5, 4.5) for next update)
+                   # Starting at -0.5 and ending at 4.5 gives much nicer 
+                   # spacing on the axis than "0, 5"
+                   range = list(-0.5, 4.5),
                    showline = TRUE, 
                    ticks = "outside"),
       
@@ -207,7 +214,7 @@ output$EQ1_plot2_areaType_output <- renderUI({
   shinyWidgets::pickerInput(
     "EQ1_plot2_areaType",
     label = "Select type of geography:",
-    choices = unique_area_types,
+    choices = EQ1_unique_area_types,
     selected = "Health board"
   )
 })

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -75,16 +75,14 @@ output$S2_trendPlot <- renderPlotly({
        # reminder title is below this code. 
            yaxis = list(
              # Wrap the y axis title in spaces so it doesn't cover the tick labels.
-             title = #list(
-               paste0(c(rep("&nbsp;", 20),
-                        "Percentage (%)", 
-                        rep("&nbsp;", 20),
-                        rep("\n&nbsp;", 3)),
-                      collapse = ""),
-                     #font = list(size = 13)),
+             title = paste0(c(rep("&nbsp;", 20),
+                              "Percentage (%)", 
+                              rep("&nbsp;", 20),
+                              rep("\n&nbsp;", 3)),
+                            collapse = ""),
              exponentformat = "none",
              separatethousands = TRUE,
-             range = c(0, max(S2_trendPlot_data()$percentage_followed_up, na.rm = TRUE) * 110 / 100), 
+             range = c(0, 105),   # Max is 105 as values are percentages and we have at least one 100%
              showline = TRUE, 
              ticks = "outside"
            ),
@@ -98,6 +96,13 @@ output$S2_trendPlot <- renderPlotly({
                                          rep("&nbsp;", 20),
                                          rep("\n&nbsp;", 3)),
                                        collapse = ""),
+                        # For range - we have 12 quarters up to Dec 2024 - this will 
+                        # need to be updated when new quarters are added to the code. 
+                        # Edit will be to add 1 to the second figure with each new 
+                        # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
+                        # Starting at -0.5 and ending at 11.5 gives much nicer 
+                        # spacing on the axis than "0, 12"
+                        range = list(-0.5, 11.5), 
                         showline = TRUE, 
                         ticks = "outside"),
            
@@ -224,7 +229,7 @@ S2_plot2_data_for_table <- reactive({
    S2_data %>% 
       select(nhs_health_board, year_months, number_of_patients_followed_up, 
              total_number_of_discharged_patients, percentage_followed_up) %>%
-      filter(year_months %in% input$S2_plot2_quarter)
+      filter(year_months %in% input$S2_plot2_quarter) 
 })
 
 
@@ -247,7 +252,7 @@ output$S2_plot2 <- renderPlotly({
    # Assigning to an object so can add "NA" annotations after:
  S2_plotly_graph2 <- plot_ly(data = S2_plot2_data(),
           
-          x = ~graph_value, y = ~nhs_health_board, # x = ~percentage_followed_up,  
+          x = ~graph_value, y = ~nhs_health_board, # x = ~percentage_followed_up,
           # Tooltip text
           text = paste0("Calendar quarter: ", S2_plot2_data()$year_months, 
                         "<br>",
@@ -288,6 +293,7 @@ output$S2_plot2 <- renderPlotly({
                                   rep("&nbsp;", 20),
                                   rep("\n&nbsp;", 3)),
                                 collapse = ""),
+                 range = list(0, 102),   # X axis is percentage and 102 means we always see the "100" axis tick
                  showline = TRUE, 
                  ticks = "outside"),
     
@@ -395,7 +401,7 @@ output$S2_2_table_download <- downloadHandler(
          filter(nhs_health_board %in% input$S2_Plot3_hbName) 
    })
   
-   
+  
    S2_plot3_data_for_table <- reactive({
       S2_data %>%
          filter(nhs_health_board %in% input$S2_Plot3_hbName) %>%
@@ -457,30 +463,21 @@ output$S2_plot3_title <- renderUI({
                # reminder title is below this code. 
                    yaxis = list(exponentformat = "none",
                                 separatethousands = TRUE,  
-                                range = c(0, max(S2_plot3_data_for_graph()$number) * 110 / 100), 
+                                # For range: "max()*1.3" shows tick mark above all max values for all HBs. 
+                                range = list(0, max(S2_plot3_data_for_graph()$number, na.rm = TRUE) * 1.3),
                                 # Wrap the y axis title in spaces so it doesn't cover the tick labels:
                                 title = paste0(c(rep("&nbsp;", 20),
                                                  print("Number of Patients"), 
                                                  rep("&nbsp;", 20),
                                                  rep("\n&nbsp;", 3)),
-                                               collapse = ""),#),
+                                               collapse = ""),
                                 showline = TRUE, 
                                 ticks = "outside"
                                 ),
                    
-                   xaxis = list(# X axis won't show quarters until there is one with data in it
-                      # e.g. NHS D&G only have data from Jan 2023 so the axis starts there 
-                      # instead of Jan 2022. The table is correct and showing NAs, but the 
-                      # below isn't working. 
-                      # type = "category",   # Ensures months aren't removed if there is no data
-                      #  tickmode = "array",         # Ensure all months are ticked
-                      #  tickvals = S2_plot3_data_for_graph()$year_months, # Explicitly set tick values to include all months
-                      #  ticktext = S2_plot3_data_for_graph()$year_months,  # Set the text of ticks to be the month names
-                      type = "category",   # meant to ensure that quarters aren't removed if there is no data
-                      tickmode = "array", S2_plot3_data_for_graph()$year_months, # meant to ensure that all quarters are ticked
-                      tickvals = levels(S2_plot3_data_for_graph()$year_months),  # Explicitly setting the tickvals to all factor levels
-                      ticktext = levels(S2_plot3_data_for_graph()$year_months),   # Ensuring that all levels appear as labels       
-                      tickangle = -45,    # Diagonal x-axis ticks
+                   xaxis = list(# For range explanation: see same note in Graph 1 xaxis
+                                range = list(-0.5, 11.5), 
+                                tickangle = -45,    # Diagonal x-axis ticks
                                 title = paste0(c(rep("&nbsp;", 20),
                                                  "<br>",
                                                  "<br>",

--- a/modules/indicators/S5_server.R
+++ b/modules/indicators/S5_server.R
@@ -79,8 +79,8 @@ output$S5_trendPlot <- renderPlotly({
              # reminder title is below this code. 
              yaxis = list(exponentformat = "none",
                           separatethousands = TRUE,  # it's per 1,000 so do we need to do this? 
-                          range = c(0, max(S5_trendPlot_data()$incidents_per_1000_bed_days, na.rm = TRUE) * 110 / 100), 
-                        
+                          range = c(0, max(S5_trendPlot_data()$incidents_per_1000_bed_days, na.rm = TRUE) * 1.3), 
+                         
                         
                          # Wrap the y axis title in spaces so it doesn't cover the tick labels.
                          title = paste0(c(rep("&nbsp;", 20),
@@ -100,6 +100,13 @@ output$S5_trendPlot <- renderPlotly({
                                            rep("&nbsp;", 20),
                                            rep("\n&nbsp;", 3)),
                                          collapse = ""),
+                          # For range: we have 12 quarters up to Dec 2024 - this will 
+                          # need to be updated when new quarters are added to the code. 
+                          # Edit will be to add 1 to the second figure with each new 
+                          # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
+                          # Starting at -0.5 and ending at 11.5 gives much nicer 
+                          # spacing on the axis than "0, 12"
+                          range = list(-0.5, 11.5),
                           showline = TRUE, 
                           ticks = "outside"),
              
@@ -267,6 +274,8 @@ output$S5_plot2 <- renderPlotly({
                                            rep("&nbsp;", 20),
                                            rep("\n&nbsp;", 3)),
                                          collapse = ""),
+                          range = c(0, max(S5_plot2_data()$incidents_per_1000_bed_days, na.rm = TRUE) * 1.2), 
+                          # re: range - "*1.2" is showing the final tick on the axis for all quarters (in April 2025 release) 
                           showline = TRUE, 
                           ticks = "outside"),
              # Set graph margins:


### PR DESCRIPTION
Axis ticks and ranges: 
- Several graphs weren’t starting from “0” and/or were missing axis ticks for Quarters or Years if the data was “NA” for that row of data. Fixed these - the first axis tick is now always the earliest date, and the last axis tick is now always the most recent date (and there are no gaps in the ticks).

Tables:
- EQ1 and E1 tables were ordered by most recent year so changed this so they are arranged in the same order as the graph shows the data. 

