### PR TITLE
58 hb returns data updates

### DIFF
--- a/data_preparation.R
+++ b/data_preparation.R
@@ -119,9 +119,6 @@ EF5_hb_names <- EF5_data %>%
 EF5_trend_measures <- EF5_data %>% 
   distinct(measure) %>%  pull(measure)
 
-# # Create data for measures bar chart (ggplot version)
-# EF5_measure_data <- EF5_data %>% 
-#   filter(measure != "Percentage 'Did Not Attend' appointments")
 
 # Create data for EF5 (need one column for each bar trace)
 EF5_measure_data <- EF5_data %>% 
@@ -130,16 +127,12 @@ EF5_measure_data <- EF5_data %>%
   rename(DNA_appointments = "Number of 'Did Not Attend' appointments",
          total_appointments = "Total number of appointments")
 
-
-# # Isolate measures for measurePlot bar elements
-# EF5_number_measures <- EF5_data %>% 
-#   subset(measure != "Percentage 'Did Not Attend' appointments") %>% 
-#   distinct(measure) %>%  pull(measure)
     
 # Isolate measure data for measurePlot line element overlay
 EF5_percentage_measure <- EF5_data %>% 
   subset(measure == "Percentage 'Did Not Attend' appointments") %>% 
   select(!measure) %>% rename(percentage = value)
+
 
 
 ## S2 ---- 
@@ -149,17 +142,10 @@ S2_data <- read.csv("data/S2.csv") %>%
    # Using months in order function to factor relevel the year_months variable
    months_function(., year_months)   
 
-
+# For graph 3:
 S2_pivoted_data <- read.csv("data/S2_Reformated.csv") %>% 
-   # select(nhs_health_board, year_months, number_of_patients_followed_up,
-   #        total_number_of_discharged_patients) %>%
-   # rename("Number of patients followed up" = "number_of_patients_followed_up", 
-   #        "Total number of discharged inpatients" = "total_number_of_discharged_patients") %>% 
-   # tidyr::pivot_longer(cols = c("Number of patients followed up", "Total number of discharged inpatients"),
-   #                     names_to = "total_or_followed_up",
-   #                     values_to = "number",
-   #                     values_drop_na = FALSE) %>%
    mutate(number = as.double(number)) %>% 
+  # Trying to stop legend ordering alphabetically, but this isn't working yet:
    mutate(total_or_followed_up = fct_relevel(total_or_followed_up, 
                                              "Total number of discharged inpatients", 
                                              "Number of patients followed up")) %>% 

--- a/data_preparation.R
+++ b/data_preparation.R
@@ -13,9 +13,11 @@ months_function <- function(dat, var) {
                                     "Jan-Mar 2023", "Apr-Jun 2023", 
                                     "Jul-Sep 2023", "Oct-Dec 2023",
                                     "Jan-Mar 2024", "Apr-Jun 2024", 
-                                    "Jul-Sep 2024", "Oct-Dec 2024"#,
-                                    #"Jan-Mar 2025", "Apr-Jun 2025", 
-                                    #"Jul-Sep 2025", "Oct-Dec 2025"))
+                                    "Jul-Sep 2024", "Oct-Dec 2024",
+                                    "Jan-Mar 2025"#, "Apr-Jun 2025", 
+                                  #  "Jul-Sep 2025", "Oct-Dec 2025",
+                                  #  "Jan-Mar 2026", "Apr-Jun 2026", 
+                                  #  "Jul-Sep 2026", "Oct-Dec 2026"))
       ))
    }
 

--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -112,7 +112,7 @@ output$EF5_trendPlot <- renderPlotly({
                            # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                            # Starting at -0.5 and ending at 11.5 gives much nicer 
                            # spacing on the axis than "0, 12"
-                           range = list(-0.5, 11.5), 
+                           range = list(-0.5, 12.5), 
                            showline = TRUE, 
                            ticks = "outside"),
               
@@ -345,12 +345,6 @@ output$EF5_measurePlot <- renderPlotly({
 
 ### Table below EF5 HB measure graph ----
 
-# ## Table Data Reactive ----
-# # to create graph data based on HB selection
-# EF5_measurePlot_tableData <- reactive({
-#   EF5_data %>%
-#     filter(hb_name %in% input$EF5_measurePlot_hbName)
-# })
 
 # Table data output
 output$EF5_measurePlot_table <- renderDataTable({

--- a/modules/indicators/EF5_ui.R
+++ b/modules/indicators/EF5_ui.R
@@ -138,7 +138,9 @@ tabItem(tabName = "EF5_tab",
                     box(width = NULL,
                         h2("Data source information and notes:"),
                         p("The data for EF5 is sourced from health board returns 
-                        which are submitted quarterly and may be incomplete."), 
+                        which are submitted quarterly and may be incomplete.
+                        Data completeness and performance against an indicator 
+                        can vary between boards."), 
                         p("Board returns for January-March 2025 have been received from: 
                         NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
                         NHS Forth Valley, NHS Grampian, NHS Highland, 

--- a/modules/indicators/EF5_ui.R
+++ b/modules/indicators/EF5_ui.R
@@ -11,7 +11,7 @@ tabItem(tabName = "EF5_tab",
           h1(paste0(
             "EF5 - Percentage (%) of 'Did Not Attend' appointments for community based ",
             "services of people with mental health conditions")),
-          h3("Last Updated: March 2025"),
+          h3("Last Updated: July 2025"),
           
           hr(),       # page break
           
@@ -139,11 +139,11 @@ tabItem(tabName = "EF5_tab",
                         h2("Data source information and notes:"),
                         p("The data for EF5 is sourced from health board returns 
                         which are submitted quarterly and may be incomplete."), 
-                        p("Board returns for Oct-Dec 2024 have been received from: 
-                          NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
-                          NHS Forth Valley, NHS Grampian, NHS Greater Glasgow & Clyde, 
-                          NHS Highland, NHS Lanarkshire, NHS Lothian, NHS Shetland, 
-                          NHS Tayside and NHS Western Isles."), 
+                        p("Board returns for January-March 2025 have been received from: 
+                        NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
+                        NHS Forth Valley, NHS Grampian, NHS Highland, 
+                        NHS Lothian, NHS Orkney, NHS Shetland, and 
+                        NHS Western Isles."), 
                         p("All community mental health outpatient appointments, 
                           all ages and all care groups are included."), 
                         p("All reasons for 'Did Not Attend' are included but not 

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -96,13 +96,14 @@ output$S2_trendPlot <- renderPlotly({
                                          rep("&nbsp;", 20),
                                          rep("\n&nbsp;", 3)),
                                        collapse = ""),
-                        # For range - we have 12 quarters up to Dec 2024 - this will 
-                        # need to be updated when new quarters are added to the code. 
-                        # Edit will be to add 1 to the second figure with each new 
-                        # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
-                        # Starting at -0.5 and ending at 11.5 gives much nicer 
-                        # spacing on the axis than "0, 12"
-                        range = list(-0.5, 11.5), 
+                        # For range - in July 2025, we have 13 quarters of data 
+                        # up to Mar 2024 - this will need to be updated when new 
+                        # quarters are added to the code. 
+                        # The edit will be to add 1 to the second figure with each new 
+                        # quarter (i.e. it will be (-0.5, 13.5) for October 2025 update)
+                        # For July 2025, starting the range at -0.5 and ending at 
+                        # 12.5 gives much nicer spacing on the axis than "0, 13"
+                        range = list(-0.5, 12.5), 
                         showline = TRUE, 
                         ticks = "outside"),
            
@@ -203,7 +204,7 @@ output$S2_plot2_quarter_output <- renderUI({
       "S2_plot2_quarter",
       label = "Select calendar quarter:",
       choices = unique(S2_data$year_months),
-      selected = "Oct-Dec 2024")
+      selected = "Jan-Mar 2025")
 })
 
 ## Selecting appropriate data for graph 2 ---- 
@@ -476,7 +477,7 @@ output$S2_plot3_title <- renderUI({
                                 ),
                    
                    xaxis = list(# For range explanation: see same note in Graph 1 xaxis
-                                range = list(-0.5, 11.5), 
+                                range = list(-0.5, 12.5), 
                                 tickangle = -45,    # Diagonal x-axis ticks
                                 title = paste0(c(rep("&nbsp;", 20),
                                                  "<br>",

--- a/modules/indicators/S2_ui.R
+++ b/modules/indicators/S2_ui.R
@@ -18,7 +18,7 @@ tabItem(tabName = "S2_tab",
            h1(paste0(
              "S2 - Percentage (%) of all discharged psychiatric inpatients ",
              "followed up by community mental health services within 7 calendar days")),
-           h3("Last Updated: March 2025"),
+           h3("Last Updated: July 2025"),
            
            hr(),       # page break
            
@@ -214,10 +214,10 @@ tabItem(tabName = "S2_tab",
                  p("The data for S2 is sourced from health board returns which 
                  are submitted quarterly and may be incomplete. Data for NHS Orkney 
                  and NHS Shetland are included in the NHS Grampian figures."),
-                 p("Board returns for Oct-Dec 2024 have been received from: 
+                 p("Board returns for January-March 2025 have been received from: 
                  NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
-                 NHS Forth Valley, NHS Grampian, NHS Greater Glasgow & Clyde, 
-                 NHS Highland, NHS Lothian, NHS Tayside and 
+                 NHS Forth Valley, NHS Grampian, 
+                 NHS Highland, NHS Lothian, and 
                  NHS Western Isles."), 
                  p("Data from all hospital psychiatric inpatient wards and from 
                  all community mental health services of all care groups and 

--- a/modules/indicators/S2_ui.R
+++ b/modules/indicators/S2_ui.R
@@ -212,8 +212,10 @@ tabItem(tabName = "S2_tab",
              box(width = NULL,
                  h2("Data source information and notes:"),
                  p("The data for S2 is sourced from health board returns which 
-                 are submitted quarterly and may be incomplete. Data for NHS Orkney 
-                 and NHS Shetland are included in the NHS Grampian figures."),
+                 are submitted quarterly and may be incomplete. Data completeness 
+                 and performance against an indicator can vary between boards."),
+                 p("Data for NHS Orkney and NHS Shetland are included in the NHS 
+                   Grampian figures."),
                  p("Board returns for January-March 2025 have been received from: 
                  NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
                  NHS Forth Valley, NHS Grampian, 

--- a/modules/indicators/S5_server.R
+++ b/modules/indicators/S5_server.R
@@ -106,7 +106,7 @@ output$S5_trendPlot <- renderPlotly({
                           # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                           # Starting at -0.5 and ending at 11.5 gives much nicer 
                           # spacing on the axis than "0, 12"
-                          range = list(-0.5, 11.5),
+                          range = list(-0.5, 12.5),
                           showline = TRUE, 
                           ticks = "outside"),
              
@@ -199,7 +199,7 @@ output$S5_plot2_quarter_output <- renderUI({
       "S5_plot2_quarter",
       label = "Select calendar quarter:",
       choices = unique(S5_data$year_months),
-      selected = "Oct-Dec 2024")
+      selected = "Jan-Mar 2025")
 })
 
 ## Selecting appropriate data for graph 2 ---- 

--- a/modules/indicators/S5_ui.R
+++ b/modules/indicators/S5_ui.R
@@ -146,13 +146,18 @@ tabItem(tabName = "S5_tab",
              box(width = NULL,
                  h2("Data source information and notes:"),
                  p("The data for S5 is sourced from health board returns which are submitted 
-                    quarterly and may be incomplete. Data for NHS Orkney 
-                    and NHS Shetland are included in the NHS Grampian figures."),
+                    quarterly and may be incomplete. Data completeness and performance 
+                    against an indicator can vary between boards."),
+                 p("Data for NHS Orkney and NHS Shetland are included in the NHS Grampian figures."),
                  p("Board returns for January-March 2025 have been received from: 
                  NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
                  NHS Forth Valley, NHS Grampian, 
                  NHS Highland, NHS Lothian, and 
                  NHS Western Isles."), 
+                 p("To ensure accurate reporting, NHS Dumfries & Galloway data for 
+                 Jan-Mar 2025 is not available as they are in the process of transitioning 
+                 between data reporting software systems. Future submissions are expected 
+                   to be accurate."),
                  p("Please note that multiple incidents can be linked to individual patients."),
                  p("'Physical violence' means physical harm inflicted on a person from another. 
                     This includes violence committed on or by any person including staff, 

--- a/modules/indicators/S5_ui.R
+++ b/modules/indicators/S5_ui.R
@@ -16,7 +16,7 @@ tabItem(tabName = "S5_tab",
      # Title for S5 tab ----
           
           h1("S5 - Incidents of physical violence per 1,000 occupied psychiatric bed days"),
-          h3("Last Updated: March 2025"),
+          h3("Last Updated: July 2025"),
           
           hr(),       # page break
           
@@ -148,11 +148,11 @@ tabItem(tabName = "S5_tab",
                  p("The data for S5 is sourced from health board returns which are submitted 
                     quarterly and may be incomplete. Data for NHS Orkney 
                     and NHS Shetland are included in the NHS Grampian figures."),
-                 p("Board returns for Oct-Dec 2024 have been received from: 
+                 p("Board returns for January-March 2025 have been received from: 
                  NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
-                 NHS Forth Valley, NHS Grampian, NHS Greater Glasgow & Clyde, 
-                 NHS Highland, NHS Lanarkshire, NHS Lothian, NHS Tayside and 
-                 NHS Western Isles."),
+                 NHS Forth Valley, NHS Grampian, 
+                 NHS Highland, NHS Lothian, and 
+                 NHS Western Isles."), 
                  p("Please note that multiple incidents can be linked to individual patients."),
                  p("'Physical violence' means physical harm inflicted on a person from another. 
                     This includes violence committed on or by any person including staff, 

--- a/modules/sidebar_ui.R
+++ b/modules/sidebar_ui.R
@@ -27,9 +27,9 @@ sidebarMenu(
   menuItem("Safe :"),
   menuItem("S1 - Suicide", tabName = "S1_tab", icon = icon("image")),
   menuItem("S2 - Community Follow-up", tabName = "S2_tab", icon = icon("bar-chart"), 
-           badgeLabel = "New", badgeColor = "green"),
+           badgeLabel = "Updated", badgeColor = "orange"),
   menuItem("S5 - Physical Violence", tabName = "S5_tab", icon = icon("bar-chart"), 
-           badgeLabel = "New", badgeColor = "green"),
+           badgeLabel = "Updated", badgeColor = "orange"),
             
   br(),
   ## Person Tabs ----           
@@ -52,7 +52,7 @@ sidebarMenu(
   menuItem("EF 3 - Psychiatric Beds", tabName = "EF3_tab", icon = icon("image")),
   menuItem("EF 4 - Mental Health Spend", tabName = "EF4_tab", icon = icon("bar-chart")),
   menuItem("EF 5 - Community DNA", tabName = "EF5_tab", icon = icon("bar-chart"), 
-           badgeLabel = "New", badgeColor = "green"),
+           badgeLabel = "Updated", badgeColor = "orange"),
             
   br(),
   ## Equitable Tabs ----           


### PR DESCRIPTION
Indicators S2, S5 and EF5 have new quarterly data to be added to their graphs and tables. Dashboard updates:

1. All graphs - ensure that the newest quarter's data is displayed and that graph axes have extended to allow this.
2. All tables - ensure values for the newest quarter are shown in tables.
3. Drop-down boxes for user selection - ensure the newest quarter can be selected where this is an option.
4. Notes and Links - edit or update the notes and links at the bottom of each indicator's page where required.
5. "Last Updated: xxxx" - edit the date underneath the title of each indicator's page.
6. Side bar - change icons from "New" to "Updated" for all three indicators.
7. Scotland Hub - update dates and values for all three indicators (to be done externally when all data is in)
8. Data Tab - ensure the updated data is included in the csv downloads.