### PR TITLE
63 adding notes to infographics indicators

### DIFF
--- a/modules/glossary_ui.R
+++ b/modules/glossary_ui.R
@@ -85,8 +85,16 @@ tabItem(tabName = "glossary",
               necessary as a matter of urgency to detain a patient in hospital 
               for the purpose of permitting a full assessment of their mental state, 
               or where if the patient were not detained in hospital there would 
-              be a significant risk to either themselves or others."),
-            
+              be a significant risk to either themselves or others. An EDC can be 
+              issued by any doctor, with the input of a mental health officer (MHO), 
+              which allows someone to be kept in hospital for up to 72 hours. 
+              For further information on compulsory treatment under the Mental 
+              Health act, see from page 11 of the ",
+                a(href = "https://www.mwcscot.org.uk/sites/default/files/2025-03/MHA-MonitoringReport-2023-24.pdf", 
+                target = "_blank", 
+                "Mental Welfare Commission for Scotland Mental Health Act monitoring 
+                report 2023-24")),
+        
             hr(), 
             
             
@@ -179,15 +187,20 @@ tabItem(tabName = "glossary",
             hr(),
             
             
-            h3("NRAC"),
+            h3("NRAC - National Resource Allocation Committee"),
             
-              p("The NHS Scotland Resource Allocation Committee (NRAC) is the 
+              p("The National Resource Allocation Committee (NRAC) is the 
               body that developed the Scottish Resource Allocation Formula. The 
-              formula is used in the allocation of around 70% of the total NHS 
-              Budget between the 14 territorial NHS Boards in Scotland. 
-              This provides funding to NHS Boards for the provision of Hospital 
-              & Community Health Services (HCHS) and GP Prescribing."),
-            
+              formula is used to predict and advise how the allocation of around 
+              70% of the total NHS Budget between the 14 territorial NHS Boards 
+              in Scotland is distributed in each financial year. This provides 
+              funding to NHS Boards for the provision of Hospital and Community 
+              Health Services (HCHS) and GP Prescribing."), 
+              p("More information can be found in the ", 
+              a(href = "https://www.publichealthscotland.scot/publications/show-all-releases?id=20539", 
+                target = "_blank", 
+                "Resource Allocation Formula (NRAC) publications.")),
+        
             hr(),
             
             

--- a/modules/indicators/EF1_ui.R
+++ b/modules/indicators/EF1_ui.R
@@ -9,23 +9,37 @@ tabItem(tabName = "EF1_tab",
                 alt = EF1_infographic_alt_text)
             )
           ),
+          
           fluidRow(
             box(width = 9,
-            p("The data for EF1 is sourced from ",
-              a(href="https://www.nssdiscovery.scot.nhs.uk/",
-                target = "_blank",
-                "Discovery"),
-              " using ", 
-              a(href="https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/what-are-the-smr-datasets/",
-                target = "_blank",
-                "SMR04"),
-              " data. ",
-              a(href="https://publichealthscotland.scot/services/data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/",
-                target = "_blank",
-                "Data completeness"),
-              " for SMR04 was around 90% or better when the data was accessed.")
+                h2("Data source information and notes:"),
+                p("The data for EF1 is sourced from ",
+                  a(href = "https://www.nssdiscovery.scot.nhs.uk/",
+                    target = "_blank",
+                    "Discovery"),
+                  " using SMR04 (Scottish Morbidity Records) data ", 
+                  a("(see Glossary for more information on SMR04).",
+                    href = "#shiny-tab-glossary", 
+                    "data-toggle" = "tab"),
+                  " NHS Board level data is available from the Discovery 
+                  online management information system to health and social care 
+                  staff from organisation across Scotland including: Scottish 
+                  Government, territorial and special health boards, local 
+                  authorities and health and social care partnerships. Discovery 
+                  is not open to members of the public, the press, academia, or 
+                  researchers. Financial year ",
+                  a(href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/",
+                    target = "_blank",
+                    "data completeness"),
+                  " for SMR04 was around 94% or more for most Boards when the data 
+                  was accessed. Published monthly, estimates of completeness of 
+                  SMR records in recent years can be found ", 
+                  a(href = "https://www.opendata.nhs.scot/dataset/scottish-morbidity-record-completeness", 
+                    target = "_blank",
+                    "here.")),
+                p("Next update: July 2026")
             )
-          ),
+          ),  
           
           fluidRow(
               column(4, actionButton(inputId = "EF1_scot_hub_button", 

--- a/modules/indicators/EF2_ui.R
+++ b/modules/indicators/EF2_ui.R
@@ -13,7 +13,7 @@ tabItem(tabName = "EF2_tab",
           fluidRow(
             box(width = 9,
                 h2("Data source information and notes:"),
-                p("The data for EF1 is sourced from ",
+                p("The data for EF2 is sourced from ",
                   a(href = "https://www.nssdiscovery.scot.nhs.uk/",
                     target = "_blank",
                     "Discovery"),

--- a/modules/indicators/EF2_ui.R
+++ b/modules/indicators/EF2_ui.R
@@ -9,23 +9,37 @@ tabItem(tabName = "EF2_tab",
                          alt = EF2_infographic_alt_text)
                    )
           ),
+          
           fluidRow(
             box(width = 9,
-                   p("The data for EF2 is sourced from ",
-                     a(href="https://www.nssdiscovery.scot.nhs.uk/",
-                       target = "_blank",
-                       "Discovery"),
-                     " using ", 
-                     a(href="https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/what-are-the-smr-datasets/",
-                       target = "_blank",
-                       "SMR04"),
-                     " data. ",
-                     a(href="https://publichealthscotland.scot/services/data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/",
-                       target = "_blank",
-                       "Data completeness"),
-                     " for SMR04 was around 90% or better when the data was accessed.")
-                 )
-          ),
+                h2("Data source information and notes:"),
+                p("The data for EF1 is sourced from ",
+                  a(href = "https://www.nssdiscovery.scot.nhs.uk/",
+                    target = "_blank",
+                    "Discovery"),
+                  " using SMR04 (Scottish Morbidity Records) data ", 
+                  a("(see Glossary for more information on SMR04).",
+                    href = "#shiny-tab-glossary", 
+                    "data-toggle" = "tab"),
+                  " NHS Board level data is available from the Discovery 
+                  online management information system to health and social care 
+                  staff from organisation across Scotland including: Scottish 
+                  Government, territorial and special health boards, local 
+                  authorities and health and social care partnerships. Discovery 
+                  is not open to members of the public, the press, academia, or 
+                  researchers. Financial year ",
+                  a(href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/",
+                    target = "_blank",
+                    "data completeness"),
+                  " for SMR04 was around 94% or more for most Boards when the data 
+                  was accessed. Published monthly, estimates of completeness of 
+                  SMR records in recent years can be found ", 
+                  a(href = "https://www.opendata.nhs.scot/dataset/scottish-morbidity-record-completeness", 
+                    target = "_blank",
+                    "here.")),
+                p("Next update: July 2026")
+            )
+          ),  
           
           fluidRow(
               column(4, actionButton(inputId = "EF2_scot_hub_button", 

--- a/modules/indicators/EF3_ui.R
+++ b/modules/indicators/EF3_ui.R
@@ -9,18 +9,56 @@ tabItem(tabName = "EF3_tab",
                 alt = EF3_infographic_alt_text)
             )
           ),
+          
           fluidRow(
             box(width = 9,
-            p("The numerator for EF3 is sourced from ",
-              a(href="https://publichealthscotland.scot/publications/acute-hospital-activity-and-nhs-beds-information-annual/",
-                target = "_blank",
-                "the Acute hospital activity and NHS beds information annual release publication, "),
-              "and the denominator is sourced from ",
-              a(href="https://www.publichealthscotland.scot/publications/resource-allocation-formula-nrac/resource-allocation-formula-nrac-for-nhsscotland-results-for-financial-year-2024-to-2025/",
-                target = "_blank",
-                "the National Resource Allocation publication."))
+                h2("Data source information and notes:"),
+                p("This indicator provides information on the average number of 
+                available staffed beds per day for mental health and learning 
+                disability specialities for adults and children per 100,000 
+                population (National Resource Allocation Committee (NRAC) adjusted). 
+                NRAC provides a formula for dividing resources for hospital and 
+                community health services and GP prescribing between the 14 
+                territorial Health Boards. Mental health and learning specialties 
+                include the following specialties:- G1: General Psychiatry, G21: 
+                Child Psychiatry, G22: Adolescent Psychiatry, G3: Forensic Psychiatry, 
+                G4:Psychiatry of Old Age, G5: Learning Disabilities."), 
+                p("The numerator for EF3 is sourced from the ",
+                  a(href = "https://publichealthscotland.scot/publications/show-all-releases?id=20521",
+                    target = "_blank",
+                    "Acute hospital activity and NHS beds information annual 
+                    release publication,"),
+                  " and the denominator is sourced from the ",
+                  a(href = "https://www.publichealthscotland.scot/publications/show-all-releases?id=20539",
+                    target = "_blank",
+                    "National Resource Allocation (NRAC) publication.")), 
+                p("From the November 2023 MHQI publication onwards, the methodology 
+                and data used to calculate this indicator has been revised to ensure 
+                that it better reflects the ",
+                  a(href = "https://www.gov.scot/publications/mental-health-quality-indicators-background-secondary-definitions/pages/8/", 
+                    target = "_blank", 
+                    "original indicator definition."), 
+                  " The methodology in previous publications (September 2021, 
+                  April 2022, October 2002, and April 2023) used only average 
+                  available staffed beds per day for mental health specialties 
+                  Acute hospital activity and NHS beds information annual release 
+                  publication as the numerator and the relevant mid-year population 
+                  estimates for Scotland as the denominator, which had not been 
+                  NRAC adjusted. Due to the changes in methodology, figures from 
+                  the November 2023 publication onwards cannot be directly compared 
+                  to those previously published."), 
+                p("NHS Board level data is available from the ",
+                  a(href = "https://www.publichealthscotland.scot/resources-and-tools/medical-practice-and-pharmaceuticals/discovery/overview/what-is-discovery/", 
+                    target = "_blank", 
+                    "Discovery"), 
+                  " online management information system to health and social care 
+                  staff from organisation across Scotland including: Scottish 
+                  Government, territorial and special health boards, local authorities 
+                  and health and social care partnerships. Discovery is not open 
+                  to members of the public, the press, academia, or researchers."),
+                p("Next update: January 2026")
             )
-          ),
+          ),  
           
           fluidRow(
               column(4, actionButton(inputId = "EF3_scot_hub_button", 

--- a/modules/indicators/EF4_ui.R
+++ b/modules/indicators/EF4_ui.R
@@ -79,18 +79,35 @@ tabItem(tabName = "EF4_tab",
             column(12,
                 box(width = NULL,
                     h2("Data source information and notes:"),
-                    p("These data are sourced from data collected annually by Public Health Scotland (PHS) on expenditure within NHS Scotland, released in an ",
+                    p("Mental Health expenditure is expenditure by services in 
+                    NHS Scotland where the primary purpose of the service is the 
+                    care and/or treatment of individuals with mental health 
+                    conditions. This expenditure includes services aimed at children, 
+                    adolescents, and older adults. Services may be delivered in the 
+                    community or in hospital by a team of mental health professionals 
+                    which include Psychiatrists, Mental Health Nurses, Psychologists, 
+                    other Allied Health Professions as well as Social Workers and 
+                    Mental Health Officers. Please note that learning disability 
+                    and clinical psychology specialties are not included in the 
+                    expenditure data shown here."),
+                    p("EF4 values are sourced from data collected annually by Public 
+                    Health Scotland (PHS) on expenditure within NHS Scotland. They 
+                    are released in an ",
                       a(href="https://publichealthscotland.scot/media/31629/nhsscotland-mental-health-expenditure-2023-24.xlsx",
                         target = "_blank",
-                         "excel workbook "),
-                      "which also includes data for organisations providing these services (14 territorial NHS Boards and the State Hospital at Carstairs Lanarkshire), as part of the ",
+                         "excel workbook"),
+                      " which also includes data for organisations providing these 
+                      services (14 territorial NHS Boards and the State Hospital 
+                      at Carstairs Lanarkshire), as part of the ",
                       a(href="https://publichealthscotland.scot/publications/scottish-health-service-costs/scottish-health-service-costs-summary-for-financial-year-2023-to-2024/",
                         target = "_blank",
-                        "annual release of National Statistics covering expenditure in the financial year 2023/24."), 
-                      " Data quality issues or inconsistencies are covered in the data found here.",
-                      " Please note that this does not provide an exhaustive account of all mental health expenditure in NHS Scotland."))
+                        "annual release of National Statistics covering expenditure 
+                        in the financial year 2023/24."), 
+                      " Data quality issues or inconsistencies are covered in the 
+                      data found here."),
+                    p("Next update: April 2026"))
                 )
-            ),
+            ),  
           
           br(), 
           

--- a/modules/indicators/EF5_ui.R
+++ b/modules/indicators/EF5_ui.R
@@ -142,15 +142,20 @@ tabItem(tabName = "EF5_tab",
                         Data completeness and performance against an indicator 
                         can vary between boards."), 
                         p("Board returns for January-March 2025 have been received from: 
-                        NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
-                        NHS Forth Valley, NHS Grampian, NHS Highland, 
-                        NHS Lothian, NHS Orkney, NHS Shetland, and 
+                        NHS Ayrshire & Arran, NHS Borders, NHS Dumfries & Galloway, NHS Fife, 
+                        NHS Forth Valley, NHS Grampian, NHS Highland, NHS Lanarkshire, 
+                        NHS Lothian, NHS Orkney, NHS Shetland, NHS Tayside and 
                         NHS Western Isles."), 
-                        p("All community mental health outpatient appointments, 
-                          all ages and all care groups are included."), 
+                        p("Data for all community mental health outpatient appointments, 
+                          all ages and all care groups are requested in the 
+                          health board returns. Individual health board data may 
+                          be limited to services that record activity on specific 
+                          reporting software systems."), 
                         p("All reasons for 'Did Not Attend' are included but not 
-                          reported in this indicator.")))
-          ),
+                          reported in this indicator."),
+                        p("Next update: October 2025"))
+             )
+          ),  
          
           
           hr(), 

--- a/modules/indicators/EQ1_ui.R
+++ b/modules/indicators/EQ1_ui.R
@@ -120,19 +120,37 @@ tabItem(tabName = "EQ1_tab",
              column(12,
                     box(width = NULL,
                         h2("Data source information and notes:"),
-                        p("These data are sourced from mental health inpatient and day case Scottish Morbidity Records ", 
-                          a("(SMR04)",
-                             href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/what-are-the-smr-datasets/",
-                             target = "_blank"),
+                        p("These data are sourced from mental health inpatient 
+                          and day case (SMR04) Scottish Morbidity Records ", 
+                          a("(see Glossary for more information on SMR04)",
+                            href = "#shiny-tab-glossary", 
+                            "data-toggle" = "tab"),
                           " and death registrations data which can be found on the ",
-                          a("National Records of Scotland ",
+                          a("National Records of Scotland (NRS)",
                             # Note that page was archived on 28 November 2024: 
-                           # href="https://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/vital-events/deaths/deaths-background-information",
                             href = "https://webarchive.nrscotland.gov.uk/20241128122619/https://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/vital-events/deaths/deaths-background-information",
                             target = "_blank"),
-                          " website. Data quality issues or inconsistencies are covered in the data found here.")
+                          " website. Data quality issues or inconsistencies are 
+                          covered in the data found here."), 
+                        p("This indicator saw a change to it's methodology in 2023. 
+                        Currently, the indicator is based on patients discharged 
+                        from SMR04 in the last five calendar years, who died in the 
+                        current calendar year. Patients are aged 0-74 and age 
+                        standardised by the European standard population (ESP). 
+                        These values are divided by the published NRS premature 
+                        mortality age standardised rate for Scotland (ESP mortality 
+                        rate of those aged under 75), reported by calendar year."), 
+                        p("Prior to 2023, this indicator was based on patients 
+                          discharged from SMR04 in the previous three financial 
+                          years, who died in the current financial year. Patients 
+                          were aged 18-74 and age standardised by Scottish 
+                          population. These values were divided by Public Health 
+                          Scotland (PHS) calculated general population mortality 
+                          rates for 18-74 age-sex standardised Scottish population, 
+                          reported by financial year.")
                         )
-                    )),
+                    )
+             ),
        
           hr(),
        

--- a/modules/indicators/EQ2_ui.R
+++ b/modules/indicators/EQ2_ui.R
@@ -9,12 +9,29 @@ tabItem(tabName = "EQ2_tab",
                 alt = EQ2_infographic_alt_text)
             )
           ),
+          
           fluidRow(
             box(width = 9,
+                h2("Data source information and notes:"),
             p("This data is sourced from the  ",
-              a(href="https://www.mwcscot.org.uk/publications?type=44&leg=54",
+              a(href = "https://www.mwcscot.org.uk/publications?type=44&leg=54",
                 target = "_blank",
-                "Mental Welfare Commission."))
+                "Mental Welfare Commission"), 
+              " (MWC) and is calculated using the number of EDC notifications 
+              received by the MWC and Scottish mid-year population estimates."),
+            p("Emergency detention certificates (EDCs) are a type of compulsory 
+              treatment under the Mental Health (Care and Treatment) Scotland 
+              Act 2003. Emergency detention certificates (EDCs) are designed to 
+              be used only in crisis situations to detain a person who requires 
+              urgent care or treatment for mental ill health. An EDC can be issued 
+              by any doctor, with the input of a mental health officer (MHO), 
+              which allows someone to be kept in hospital for up to 72 hours. 
+              For further information on this data and compulsory treatment under 
+              the Mental Health act, see from page 11 of the ", 
+              a(href = "https://www.mwcscot.org.uk/sites/default/files/2025-03/MHA-MonitoringReport-2023-24.pdf", 
+                target = "_blank", 
+                "Mental Welfare Commission for Scotland Mental Health Act monitoring report 2023-24.")),
+            p("Next update: January 2026")
             )
           ),
             

--- a/modules/indicators/EQ4_ui.R
+++ b/modules/indicators/EQ4_ui.R
@@ -9,14 +9,58 @@ tabItem(tabName = "EQ4_tab",
                 alt = EQ4_infographic_alt_text)
             )
           ),
+          
           fluidRow(
             box(width = 9,
+                h2("Data source information and notes:"),
             p("The data for EQ4 is sourced from  ",
               a(href="https://www.publichealthscotland.scot/services/discovery/#section-1-1",
                 target = "_blank",
-                "Discovery."))
-            )
-          ),
+                "Discovery"),
+              " using SMR04 (Scottish Morbidity Records) data ", 
+              a("(see Glossary for more information on SMR04).",
+                href = "#shiny-tab-glossary", 
+                "data-toggle" = "tab"),
+              " NHS Board level data is available from the Discovery 
+              online management information system to health and social care 
+              staff from organisation across Scotland including: Scottish 
+              Government, territorial and special health boards, local 
+              authorities and health and social care partnerships. Discovery is 
+              not open to members of the public, the press, academia, or 
+              researchers. Financial year ",
+              a(href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/",
+                target = "_blank",
+                "data completeness"),
+              " for SMR04 was around 94% or more for most Boards when the data 
+              was accessed. Published monthly, estimates of completeness of 
+              SMR records in recent years can be found ", 
+              a(href = "https://www.opendata.nhs.scot/dataset/scottish-morbidity-record-completeness", 
+                target = "_blank",
+                "here.")),
+            # CHECK THIS
+            # p("Specialist CAMHS wards are defined as admissions to specialty G2, 
+            #   Child and Adolescent psychiatry at either Royal Hospital for Children 
+            #   (NHS Greater Glasgow & Clyde), Skye House (NHS Greater Glasgow & Clyde), 
+            #   Dudhope House (NHS Tayside) or, until March 2021, Royal Edinburgh 
+            #   Hospital (NHS Lothian)."),
+            # p("Between January 2021 and March 2021 child and adolescent psychiatry 
+            # activity transferred from a facility in the Royal Edinburgh hospital to 
+            # a facility in the Royal Hospital for Children and Young People in Edinburgh. 
+            # From January 2021 those admitted to the Royal Hospital for Children and 
+            # Young People in Edinburgh child and adolescent psychiatry, child psychiatry 
+            # or adolescent psychiatry and treated in an adolescent unit are defined as 
+            # admissions to a specialist CAMHS ward. This change in definition has been 
+            # applied retrospectively in this publication. The data for this indicator 
+            # in the April 2022 and September 2021 publications did not take into account 
+            # this change."), 
+            # p("From January 2018, Skye House changed their hospital code to the same 
+            # as Stobhill Hospital so in order to determine if an admission is to Skye 
+            # House, those admitted from 1 January 2018 with the Stobhill hospital code 
+            # to child and adolescent psychiatry, child psychiatry or adolescent 
+            # psychiatry were assumed to be in Skye House."),
+            p("Next update: July 2026")
+          )
+        ),  
             
             fluidRow(
               column(4, actionButton(inputId = "EQ2_prevButton", 

--- a/modules/indicators/P1_ui.R
+++ b/modules/indicators/P1_ui.R
@@ -15,12 +15,16 @@ tabItem(tabName = "P1_tab",
             
             fluidRow(
               box(width = 9,
-                  p("Further information can be found in the ",
+                  h2("Data source information and notes:"),
+                  p("The data is presented as a range due to it being drawn from a 
+                    survey on a sample and not population data. Further information 
+                    can be found in the ",
                     a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
                       target = "_blank",
-                      "Health and Care Experience Survey."))
-              )
-            ),  
+                      "Health and Care Experience Survey.")), 
+                  p("Next update: July 2026")
+                  )
+              ),  
             
           fluidRow(
               column(4, actionButton(inputId = "P1_scot_hub_button", 

--- a/modules/indicators/P1_ui.R
+++ b/modules/indicators/P1_ui.R
@@ -21,7 +21,17 @@ tabItem(tabName = "P1_tab",
                     can be found in the ",
                     a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
                       target = "_blank",
-                      "Health and Care Experience Survey.")), 
+                      "Health and Care Experience Survey (HACE).")), 
+                  p("The HACE survey is an online and postal survey sent to a random 
+                    sample of people registered with a general practice in Scotland. 
+                    As a successor to the GP and Local NHS Services Patient Experience 
+                    Survey, it has been run every two years since 2009. The survey 
+                    asks about people’s experiences of:"),
+                  p("- Accessing and using their general practice and out of hours 
+                  services."), 
+                  p("- Aspects of care and support provided by local authorities 
+                  and other organisations."), 
+                  p("- Caring responsibilities and related support."),
                   p("Next update: July 2026")
                   )
               ),  

--- a/modules/indicators/P2_ui.R
+++ b/modules/indicators/P2_ui.R
@@ -20,6 +20,16 @@ tabItem(tabName = "P2_tab",
                   a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
                     target = "_blank",
                     "Health and Care Experience Survey.")), 
+                p("The HACE survey is an online and postal survey sent to a random 
+                    sample of people registered with a general practice in Scotland. 
+                    As a successor to the GP and Local NHS Services Patient Experience 
+                    Survey, it has been run every two years since 2009. The survey 
+                    asks about people’s experiences of:"),
+                p("- Accessing and using their general practice and out of hours 
+                  services."), 
+                p("- Aspects of care and support provided by local authorities 
+                  and other organisations."), 
+                p("- Caring responsibilities and related support."),
                 p("Next update: July 2026")
             )
           ),

--- a/modules/indicators/P2_ui.R
+++ b/modules/indicators/P2_ui.R
@@ -7,18 +7,20 @@ tabItem(tabName = "P2_tab",
             box(width = 9,
                 img(src='infographics/P2.png',
                     class = "infographic",
-                    alt = P2_infographic_alt_text),
-                p("Due to change in the source of the indicator, the data is not comparable to previous data for 2021/22.")
-                )
-            
-          ),
+                    alt = P2_infographic_alt_text))
+            ),
           
           fluidRow(
             box(width = 9,
-                p("Further information can be found in the ",
+                h2("Data source information and notes:"),
+                p("Due to a change in the source of the indicator in 2024, the data is 
+                not comparable to previous data for 2021/22. The data is presented 
+                as a range due to it being drawn from a survey on a sample and 
+                not population data. Further information can be found in the ",
                   a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
                     target = "_blank",
-                    "Health and Care Experience Survey."))
+                    "Health and Care Experience Survey.")), 
+                p("Next update: July 2026")
             )
           ),
           

--- a/modules/indicators/P3_ui.R
+++ b/modules/indicators/P3_ui.R
@@ -7,19 +7,22 @@ tabItem(tabName = "P3_tab",
             box(width = 9,
                 img(src='infographics/P3.png',
                     class = "infographic",
-                    alt = P3_infographic_alt_text),
-                p("Due to change in the source of the indicator, the data is not comparable to previous data for 2021/22.")
-                )
-            
-          ),
+                    alt = P3_infographic_alt_text))
+            ),
+          
           
           fluidRow(
             box(width = 9,
-                p("Further information can be found in the ",
+                h2("Data source information and notes:"),
+                p("Due to a change in the source of the indicator in 2024, the data is 
+                not comparable to previous data for 2021/22. The data is presented 
+                as a range due to it being drawn from a survey on a sample and 
+                not population data. Further information can be found in the ",
                   a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
                     target = "_blank",
-                    "Health and Care Experience Survey."))
-                )
+                    "Health and Care Experience Survey.")), 
+                p("Next update: July 2026")
+            )
           ),
           
   

--- a/modules/indicators/P3_ui.R
+++ b/modules/indicators/P3_ui.R
@@ -21,6 +21,16 @@ tabItem(tabName = "P3_tab",
                   a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
                     target = "_blank",
                     "Health and Care Experience Survey.")), 
+                p("The HACE survey is an online and postal survey sent to a random 
+                    sample of people registered with a general practice in Scotland. 
+                    As a successor to the GP and Local NHS Services Patient Experience 
+                    Survey, it has been run every two years since 2009. The survey 
+                    asks about people’s experiences of:"),
+                p("- Accessing and using their general practice and out of hours 
+                  services."), 
+                p("- Aspects of care and support provided by local authorities 
+                  and other organisations."), 
+                p("- Caring responsibilities and related support."),
                 p("Next update: July 2026")
             )
           ),

--- a/modules/indicators/P4_ui.R
+++ b/modules/indicators/P4_ui.R
@@ -20,7 +20,7 @@ tabItem(tabName = "P4_tab",
                 p("This data is sourced from the ", 
                   a(href = "https://www.mwcscot.org.uk/publications?type=44&leg=54",
                     target = "_blank",
-                    "Mental Welfare Commission"), "."),
+                    "Mental Welfare Commission (MWC).")),
                 p("The advance statement register has been in operation since 2017. 
                 Advance statements are written statements made by a person when 
                 they are well, setting out the care and treatment they would prefer 
@@ -32,10 +32,10 @@ tabItem(tabName = "P4_tab",
                   a(href = "https://www.mwcscot.org.uk/sites/default/files/2025-03/MHA-MonitoringReport-2023-24.pdf",
                     target = "_blank", 
                     "Mental Welfare Commission for Scotland Mental Health Act 
-                    monitoring report 2023-24"), "."),
+                    monitoring report 2023-24.")),
                 p("It is assumed that the drop in individuals who had a first 
                   engagement with the advance statement register in 2020/21 
-                  indicates a significant impact of the pandemic on services’ 
+                  indicates a significant impact of the pandemic on service's 
                   ability to engage with individuals on matters to do with advance 
                   care planning."),
                 p("Next update: January 2026")

--- a/modules/indicators/P4_ui.R
+++ b/modules/indicators/P4_ui.R
@@ -2,7 +2,8 @@ tabItem(tabName = "P4_tab",
         fluidPage(
           
           
-          h1("P4 - Number of people with advance statements registered per year with the Mental Welfare Commission for Scotland"),
+          h1("P4 - Number of people with advance statements registered per year 
+             with the Mental Welfare Commission for Scotland"),
           h3("Last Updated: October 2024"),
           fluidRow(
             box(width = 9,
@@ -15,12 +16,31 @@ tabItem(tabName = "P4_tab",
           
           fluidRow(
             box(width = 9,
-                p("Further information can be found in the ",
-                  a(href="https://www.gov.scot/collections/health-and-care-experience-survey/",
+                h2("Data source information and notes:"),
+                p("This data is sourced from the ", 
+                  a(href = "https://www.mwcscot.org.uk/publications?type=44&leg=54",
                     target = "_blank",
-                    "Health and Care Experience Survey."))
-                )
-          ),
+                    "Mental Welfare Commission"), "."),
+                p("The advance statement register has been in operation since 2017. 
+                Advance statements are written statements made by a person when 
+                they are well, setting out the care and treatment they would prefer 
+                or would dislike should they become mentally unwell in the future. 
+                Since 2017, each time someone either writes a statement or withdraws 
+                  a statement, health boards should notify the Mental Welfare 
+                  Commission for Scotland. More information about advance statements 
+                  can be found in pages 61 – 63 of the ", 
+                  a(href = "https://www.mwcscot.org.uk/sites/default/files/2025-03/MHA-MonitoringReport-2023-24.pdf",
+                    target = "_blank", 
+                    "Mental Welfare Commission for Scotland Mental Health Act 
+                    monitoring report 2023-24"), "."),
+                p("It is assumed that the drop in individuals who had a first 
+                  engagement with the advance statement register in 2020/21 
+                  indicates a significant impact of the pandemic on services’ 
+                  ability to engage with individuals on matters to do with advance 
+                  care planning."),
+                p("Next update: January 2026")
+            )
+          ),  
             
             
           # Navigation buttons

--- a/modules/indicators/S1_ui.R
+++ b/modules/indicators/S1_ui.R
@@ -14,15 +14,21 @@ tabItem(tabName = "S1_tab",
           
           fluidRow(
             box(width = 9,
-                p("Further information can be found on the ",
-                  a("National Records of Scotland", 
-                    # Note that page was archived on 28 November 2024: 
-                   # href= "https://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/vital-events/deaths/suicides",
-                   href = "https://webarchive.nrscotland.gov.uk/20241128122448/https://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/vital-events/deaths/suicides",
-                    target = "_blank"), 
-                  " website.")
-            )
-          ), 
+                h2("Data source information and notes:"),
+                p("These ", 
+                  a("European age-sex standardised rates", 
+                    href = "#shiny-tab-glossary", 
+                    "data-toggle" = "tab"),
+                  " are taken from the tables of the downloadable data spreadsheet 
+                  which provides information on probable suicides released by 
+                  National Records of Scotland (NRS). This data release also includes 
+                  data at NHS Board and Local Authority level. Further information 
+                  is available from the ", 
+                  a(href = "https://www.nrscotland.gov.uk/publications/probable-suicides-2023/#",
+                  target = "_blank", 
+                  "NRS probable suicide publication webpage.")),
+                p("Next update: October 2025")
+                )), 
           
           
           fluidRow(

--- a/modules/indicators/S2_ui.R
+++ b/modules/indicators/S2_ui.R
@@ -217,9 +217,9 @@ tabItem(tabName = "S2_tab",
                  p("Data for NHS Orkney and NHS Shetland are included in the NHS 
                    Grampian figures."),
                  p("Board returns for January-March 2025 have been received from: 
-                 NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
+                 NHS Ayrshire & Arran, NHS Borders, NHS Dumfries & Galloway, NHS Fife, 
                  NHS Forth Valley, NHS Grampian, 
-                 NHS Highland, NHS Lothian, and 
+                 NHS Highland, NHS Lothian, NHS Tayside, and 
                  NHS Western Isles."), 
                  p("Data from all hospital psychiatric inpatient wards and from 
                  all community mental health services of all care groups and 
@@ -234,17 +234,16 @@ tabItem(tabName = "S2_tab",
                  which can include Psychiatrists, Mental Health Nurses, Psychologists, 
                  and other Allied Health Professions as well as Social Workers 
                  and Mental Health Officers."),
-                 p(paste0("'Community mental health services' - The Scottish 
-                          Government's "),
-                   a(href = "https://www.gov.scot/publications/core-mental-health-standards/pages/12/", 
-                     "'Core mental health standards' publication", 
-                     target = "_blank"), 
-                   paste0(" states: 'Community Services: This is care and support 
-                          which can be accessed without the need to be admitted 
-                          to an inpatient hospital ward.'"))
-             )
-             )
-      ),    
+                 p("'Community mental health services' - The Scottish Government's ",
+                 a(href = "https://www.gov.scot/publications/core-mental-health-standards/pages/12/", 
+                   "'Core mental health standards' publication", 
+                   target = "_blank"), 
+                   " states: 'Community Services: This is care and support which 
+                   can be accessed without the need to be admitted to an inpatient 
+                 hospital ward.'"),
+                 p("Next update: October 2025")
+                 )
+             )),
                   
    
    hr(), # page break           

--- a/modules/indicators/S5_ui.R
+++ b/modules/indicators/S5_ui.R
@@ -150,19 +150,21 @@ tabItem(tabName = "S5_tab",
                     against an indicator can vary between boards."),
                  p("Data for NHS Orkney and NHS Shetland are included in the NHS Grampian figures."),
                  p("Board returns for January-March 2025 have been received from: 
-                 NHS Ayrshire & Arran, NHS Dumfries & Galloway, NHS Fife, 
+                 NHS Ayrshire & Arran, NHS Borders, NHS Fife, 
                  NHS Forth Valley, NHS Grampian, 
-                 NHS Highland, NHS Lothian, and 
+                 NHS Highland, NHS Lanarkshire, NHS Lothian, NHS Tayside and 
                  NHS Western Isles."), 
                  p("To ensure accurate reporting, NHS Dumfries & Galloway data for 
-                 Jan-Mar 2025 is not available as they are in the process of transitioning 
-                 between data reporting software systems. Future submissions are expected 
-                   to be accurate."),
+                 Jan-Mar 2025 are not available due to a transition between data 
+                 reporting software systems. Future submissions are expected 
+                 to be accurate."),
                  p("Please note that multiple incidents can be linked to individual patients."),
                  p("'Physical violence' means physical harm inflicted on a person from another. 
                     This includes violence committed on or by any person including staff, 
-                    patients and visitors.")))
-      ),       
+                    patients and visitors."),
+                 p("Next update: October 2025")
+             )
+      )),
       
    
    hr(),

--- a/modules/indicators/T1_ui.R
+++ b/modules/indicators/T1_ui.R
@@ -12,10 +12,16 @@ tabItem(tabName = "T1_tab",
           
           fluidRow(
           box(width = 9,
-                p("Further information can be found in the ",
-                  a(href="https://publichealthscotland.scot/publications/psychological-therapies-waiting-times/",
-                    target = "_blank",
-                    "Psychological Therapies Waiting Times publication."))
+              h2("Data source information and notes:"),
+              p("Further information can be found in the ",
+                a(href="https://publichealthscotland.scot/publications/psychological-therapies-waiting-times/",
+                  target = "_blank",
+                  "Psychological Therapies Waiting Times publication."), 
+                " The publication also provides ", 
+                a(href = "https://www.opendata.nhs.scot/dataset/psychological-therapies-waiting-times",
+                  target = "_blank",
+                  "NHS Board level open data.")), 
+              p("Next update: October 2025")
               )
           ),
           

--- a/modules/indicators/T2_ui.R
+++ b/modules/indicators/T2_ui.R
@@ -14,13 +14,19 @@ tabItem(tabName = "T2_tab",
           
           fluidRow(
             box(width = 9,
-            p("Further information can be found in the ",
-              a(href="https://publichealthscotland.scot/publications/child-and-adolescent-mental-health-services-camhs-waiting-times/",
-                target = "_blank",
-                "Child and Adolescent Mental Health Services in Scotland: Waiting Times publication."))
-            )
-          ),
-          
+                h2("Data source information and notes:"),
+                p("Further information can be found in the ",
+                  a(href="https://publichealthscotland.scot/publications/child-and-adolescent-mental-health-services-camhs-waiting-times/",
+                    target = "_blank",
+                    "Child and Adolescent Mental Health Services in Scotland: Waiting Times publication."), 
+                  " The publication also provides ", 
+                  a(href = "https://www.opendata.nhs.scot/dataset/child-and-adolescent-mental-health-waiting-times", 
+                    target = "_blank",
+                    "NHS Board level open data.")), 
+                p("Next update: October 2025")
+                )
+            ),
+        
           fluidRow(
               column(4, actionButton(inputId = "T2_scot_hub_button", 
                                      label = "Scotland Hub", icon = icon("home"),

--- a/modules/indicators/T3_ui.R
+++ b/modules/indicators/T3_ui.R
@@ -1,8 +1,8 @@
 tabItem(tabName = "T3_tab",
         fluidPage(
-          h1("T3 - % of people who wait less than three weeks from referral ",
-              "received to appropriate drug or alcohol treatment that supports ",
-              "their recovery"),
+          h1("T3 - % of people who wait less than three weeks from referral 
+             received to appropriate drug or alcohol treatment that supports 
+             their recovery"),
           h3("Last Updated: September 2024"),
           fluidRow(
             box(width = 9,
@@ -14,20 +14,39 @@ tabItem(tabName = "T3_tab",
           
           fluidRow(
             box(width = 9,
-                p(paste0(
-              "Data from City of Edinburgh Alcohol and Drug Partnership (ADP) ",
-              "have been excluded from this release as the ADP was unable to ",
-              "confirm that their data were accurate and up-to-date within the ",
-              "specified timescale. Amongst the remaining ADPs, 13 services out ",
-              "of 181 were excluded due to the absence of complete data.")),
-              br(),
-              p("Further information can be found in the ",
-                a(href="https://beta.isdscotland.org/find-publications-and-data/lifestyle-and-behaviours/substance-use/national-drug-and-alcohol-treatment-waiting-times/",
-                target = "_blank",
-                "National Drug and Alcohol Treatment Waiting Times publication.")
-              )
-            )
-          ),
+                h2("Data source information and notes:"),
+                p("Data from individual Alcohol and Drug Partnerships (ADPs) may 
+                be excluded from this release as they were unable to confirm that 
+                their data were accurate and up-to-date within the specified 
+                timescale or were excluded due to incomplete data. Further information 
+                can be found in the ",
+                  a(href="https://publichealthscotland.scot/publications/show-all-releases?id=20553",
+                  target = "_blank",
+                  "National Drug and Alcohol Treatment Waiting Times publication.")),
+                p(" The publication also provides ", 
+                  a(href = "https://www.opendata.nhs.scot/dataset/drug-and-alcohol-treatment-waiting-times",
+                  target = "_blank", 
+                  "open data"),
+                  "with breakdowns by NHS Board and Alcohol and Drug partnership, 
+                  service type (community-based or prison-based) and the substance(s) 
+                  people sought help for."), 
+                p("These data were extracted from the ", 
+                a(href = "https://publichealthscotland.scot/population-health/improving-scotlands-health/drugs/data-and-intelligence/drug-and-alcohol-information-system-daisy/about-daisy/#section-1", 
+                  target = "_blank", 
+                  "Drug and Alcohol Information System (DAISy)"), 
+                " and its predecessor the ", 
+                a(href = "https://webarchive.nrscotland.gov.uk/20231129155349/https://www.isdscotland.org/Health-Topics/Waiting-Times/Drugs-and-Alcohol/",
+                  target = "_blank", 
+                  "Drug and Alcohol Treatment Waiting Times (DATWT) database."), 
+                " DAISy has been available in all NHS boards from April 2021 and 
+                replaced two previous systems: the DATWT database and the ", 
+                a(href = "https://publichealthscotland.scot/population-health/improving-scotlands-health/drugs/data-and-intelligence/scottish-drug-misuse-database-sdmd/",
+                  target = "_blank", 
+                  "Scottish Drug Misuse Database "), 
+                  "(SDMD)."),
+                p("Next update: October 2025")
+                )
+            ),
           
             fluidRow(
               column(4, actionButton(inputId = "T3_scot_hub_button", 


### PR DESCRIPTION
The infographics indicators have links to the data source and maybe a note or two but, having discussed this with Andrew, I have added extra notes to match the information quality of the pdf publications. External links, page numbers, latest publications, appropriate notes etc have been updated for each page. 