### PR TITLE
65 tables aligning columns adding commas

### DIFF
--- a/data_preparation.R
+++ b/data_preparation.R
@@ -75,10 +75,12 @@ EQ1_plot2_data <- EQ1_reformatted_data %>%
 
 
 
-
 ## EF4 ----
 EF4_data <- read.csv("data/EF4.csv") %>% 
   select(fyear, hb_name, measure, value) %>% 
+  # filter out State Hospital and Golden Jubilee
+  filter(hb_name != "National Waiting Times Centre (Golden Jubilee)" &
+           hb_name != "State Hospital") %>% 
    # Remove the (%) from variable names used in graph 
    mutate(measure = if_else(measure == "Mental Health Expenditure (%)", 
                             "Mental Health Expenditure", measure)) %>% 

--- a/modules/indicators/EF4_server.R
+++ b/modules/indicators/EF4_server.R
@@ -166,7 +166,9 @@ EF4_trendPlot_data <- reactive({
               style = 'bootstrap',
               class = 'table-bordered table-condensed',
               rownames = FALSE,
-              options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip'),
+              options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                             # Right align numeric column - it's columns 4 but use 3 as rownames = FALSE
+                             columnDefs = list(list(className = 'dt-right', targets = 3))),
               colnames = c("Financial Year",
                            "Health Board",
                            "Measure Name",

--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -147,11 +147,24 @@ output$EF5_trendPlot <- renderPlotly({
 output$EF5_trendPlot_table <- renderDataTable({
    datatable(EF5_trendPlot_data()%>% 
                 # Add "NA" as a value to table on dashboard:
-                mutate(across(value, ~replace(., is.na(.), "NA"))),
+             #  mutate(across(value, ~replace(., is.na(.), "NA"))),
+             
+             mutate(value = case_when((input$EF5_trendPlot_measure == "Percentage 'Did Not Attend' appointments"
+                                       & is.na(value)) ~ "NA",
+                                      (input$EF5_trendPlot_measure == "Percentage 'Did Not Attend' appointments"
+                                       & !is.na(value)) ~ paste0(value, " %"), 
+                                      .default = formatC(value,
+                                                         format = "f",
+                                                         digits = 0, # digits after decimal point
+                                                         big.mark =","))),
+             
+             
              style = 'bootstrap',
              class = 'table-bordered table-condensed',
              rownames = FALSE,
-             options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip'),
+             options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                            # Right align numeric columns - it's column 4 but use 3 as rownames = FALSE
+                            columnDefs = list(list(className = 'dt-right', targets = 3))), 
              colnames = c("Health Board",
                           "Calendar Quarter",
                           "Measure",
@@ -309,7 +322,8 @@ output$EF5_measurePlot <- renderPlotly({
                              max(EF5_measurePlot_data()$graph_value_appointments) < 50000 ~ 1000,
                              max(EF5_measurePlot_data()$graph_value_appointments) < 100000 ~ 2000,
                              max(EF5_measurePlot_data()$graph_value_appointments) < 200000 ~ 5000,
-                             max(EF5_measurePlot_data()$graph_value_appointments) > 200000 ~ 10000),
+                             max(EF5_measurePlot_data()$graph_value_appointments) > 200000 ~ 10000, 
+                             .default = 500),
                x = EF5_measurePlot_data()$year_months[i],  # Position according to the correct category
                text = "NA",  # The text to display
                showarrow = FALSE,  # No arrow pointing to the text
@@ -328,7 +342,8 @@ output$EF5_measurePlot <- renderPlotly({
                              max(EF5_measurePlot_data()$graph_value_appointments) < 50000 ~ 1000,
                              max(EF5_measurePlot_data()$graph_value_appointments) < 100000 ~ 2000,
                              max(EF5_measurePlot_data()$graph_value_appointments) < 200000 ~ 5000,
-                             max(EF5_measurePlot_data()$graph_value_appointments) > 200000 ~ 10000), 
+                             max(EF5_measurePlot_data()$graph_value_appointments) > 200000 ~ 10000, 
+                             .default = 500), 
                x = EF5_measurePlot_data()$year_months[i],  # Position according to the correct category
                text = "NA",  # The text to display
                showarrow = FALSE,  # No arrow pointing to the text
@@ -352,12 +367,27 @@ output$EF5_measurePlot_table <- renderDataTable({
                # Remove columns used for adding NA annotations to graph: 
                select(!c("graph_value_DNA", "graph_value_label_DNA", 
                          "graph_value_appointments", "graph_value_label_appointments")) %>% 
-               # Add "NA" as a value to table on dashboard:
-               mutate(across(DNA_appointments:`Percentage 'Did Not Attend' appointments`, ~replace(., is.na(.), "NA"))),
+              # Add commas to large numbers but keep "NA" as a visible value on dashboard:
+              mutate(DNA_appointments = if_else(is.na(DNA_appointments), 
+                                           "NA", 
+                                           formatC(DNA_appointments,
+                                                   format = "f", digits = 0, # digits after decimal point
+                                                   big.mark =",")),
+                     total_appointments = if_else(is.na(total_appointments),
+                                                  "NA", 
+                                                  formatC(total_appointments,
+                                                          format = "f", digits = 0, # digits after decimal point
+                                                          big.mark =",")),
+                     `Percentage 'Did Not Attend' appointments` = if_else(is.na(`Percentage 'Did Not Attend' appointments`),
+                                                                          "NA",
+                                                                          paste0(`Percentage 'Did Not Attend' appointments`, " %"))),
             style = 'bootstrap',
             class = 'table-bordered table-condensed',
             rownames = FALSE,
-            options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip'),
+            options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                           # Right align numeric columns - it's columns 3:5 but use 2:4 as rownames = FALSE
+                           columnDefs = list(list(className = 'dt-right', targets = 2:4))), 
+            
             colnames = c("Health Board",
                          "Calendar Quarter",
                          "'Did Not Attend' Appointments",

--- a/modules/indicators/EQ1_server.R
+++ b/modules/indicators/EQ1_server.R
@@ -162,26 +162,35 @@ output$EQ1_plot1 <- renderPlotly({
 ## Graph 1 Table ----
 # Year, area_type, area_name, risk_ratio, SMR04_Pop_Rate, General_Pop_Rate
 output$EQ1_1_table <- renderDataTable({
-  datatable(
-    EQ1_plot1_Data(),
-    style = 'bootstrap',
-    class = 'table-bordered table-condensed',
-    rownames = FALSE,
-    options = list(
-      pageLength = 16,
-      autoWidth = FALSE,
-      dom = 'tip'
-    ),
-    colnames = c(
-      "Calendar Year",
-      "Area Type",
-      "Area Name",
-      "Risk Ratio",
-      "SMR04 Population Rate (Per 100,000)",
-      "General Population Rate (Per 100,000)"
-    )
-  )
-})
+  datatable(EQ1_plot1_Data() %>% 
+              # Add commas to large numbers but keep "NA" as a visible value on dashboard:
+              mutate(SMR04_Pop_Rate = if_else(is.na(SMR04_Pop_Rate), 
+                                           "NA", 
+                                           formatC(SMR04_Pop_Rate,
+                                                   format = "f",
+                                                   digits = 0, # digits after decimal point
+                                                   big.mark =",")),
+                     General_Pop_Rate = if_else(is.na(General_Pop_Rate),
+                                                        "NA", 
+                                                        formatC(General_Pop_Rate,
+                                                                format = "f",
+                                                                digits = 0, # digits after decimal point
+                                                                big.mark =","))),
+            style = 'bootstrap',
+            class = 'table-bordered table-condensed',
+            rownames = FALSE,
+            options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                           # Right align numeric columns - it's columns 4:6 but use 3:5 as rownames = FALSE
+                           columnDefs = list(list(className = 'dt-right', targets = 3:5))), 
+            colnames = c("Calendar Year",
+                         "Area Type",
+                         "Area Name",
+                         "Risk Ratio",
+                         "SMR04 Population Rate (Per 100,000)",
+                         "General Population Rate (Per 100,000)")
+            )
+  })
+
 
 # Create download buttons that allows users to the download tables in .csv format.
 output$EQ1_1_table_download <- downloadHandler(
@@ -353,15 +362,26 @@ output$EQ1_plot2 <- renderPlotly({
 # Rate_Type, Year, area_type, area_name, Rate
 output$EQ1_2_table <- renderDataTable({
   datatable(
-    EQ1_plot2_selectedData(),
+    EQ1_plot2_selectedData() %>% 
+      # Add commas to large numbers but keep "NA" as a visible value on dashboard:
+      mutate(mh_rate = if_else(is.na(mh_rate), 
+                                      "NA", 
+                                      formatC(mh_rate,
+                                              format = "f",
+                                              digits = 0, # digits after decimal point
+                                              big.mark =",")),
+             genpop_rate = if_else(is.na(genpop_rate),
+                                        "NA", 
+                                        formatC(genpop_rate,
+                                                format = "f",
+                                                digits = 0, # digits after decimal point
+                                                big.mark =","))),
     style = 'bootstrap',
     class = 'table-bordered table-condensed',
     rownames = FALSE,
-    options = list(
-      pageLength = 16,
-      autoWidth = FALSE,
-      dom = 'tip'
-    ),
+    options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                   # Right align numeric columns - it's columns 4:5 but use 3:4 as rownames = FALSE
+                   columnDefs = list(list(className = 'dt-right', targets = 3:4))), 
     colnames = c("Calendar year",
                  "Area Name",
                  "Area Type",

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -162,12 +162,23 @@ output$S2_trendPlot <- renderPlotly({
 
 output$S2_1_table <- renderDataTable({
    datatable(S2_trendPlot_data() %>% 
-                # Add "NA" as a value to table on dashboard: 
-                mutate(across(number_of_patients_followed_up:percentage_followed_up, ~replace(., is.na(.), "NA"))),
+               # Add "NA" as a value to table on dashboard:
+               mutate(across(number_of_patients_followed_up:total_number_of_discharged_patients, ~replace(., is.na(.), "NA"))) %>% 
+               # Add % sign to percentage variable:
+               mutate(percentage_followed_up = if_else(is.na(percentage_followed_up),
+                                                       "NA",
+                                                       paste0(percentage_followed_up, " %"))) %>% 
+               # Add commas to large values but keep "NA" or "*" character values (values are all currenlty under 1000 so don't need this yet):
+               mutate(total_number_of_discharged_patients = if_else(!grepl("\\D", total_number_of_discharged_patients), 
+                                                                    format(as.numeric(total_number_of_discharged_patients), 
+                                                                           big.mark = ",", trim = T), 
+                                                                    total_number_of_discharged_patients)),
              style = 'bootstrap',
              class = 'table-bordered table-condensed',
              rownames = FALSE,
-             options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip'),
+             options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                            # Right align numeric columns - it's columns 3:5 but use 2:4 as rownames = FALSE
+                            columnDefs = list(list(className = 'dt-right', targets = 2:4))), 
              colnames = c("Health Board",
                           "Calendar Quarter",
                           "Number of Patients Followed Up", 
@@ -341,16 +352,23 @@ output$S2_plot2 <- renderPlotly({
 output$S2_2_table <- renderDataTable({
    datatable(
       S2_plot2_data_for_table() %>% 
-         # Add "NA" as a value to table on dashboard: 
-         mutate(across(number_of_patients_followed_up:percentage_followed_up, ~replace(., is.na(.), "NA"))), 
+        # Add "NA" as a value to table on dashboard:
+        mutate(across(number_of_patients_followed_up:total_number_of_discharged_patients, ~replace(., is.na(.), "NA"))) %>% 
+        # Add % sign to percentage variable:
+        mutate(percentage_followed_up = if_else(is.na(percentage_followed_up),
+                                                "NA",
+                                                paste0(percentage_followed_up, " %"))) %>% 
+        # Add commas to large values but keep "NA" or "*" character values (values are all currenlty under 1000 so don't need this yet):
+        mutate(total_number_of_discharged_patients = if_else(!grepl("\\D", total_number_of_discharged_patients), 
+                                                             format(as.numeric(total_number_of_discharged_patients), 
+                                                                    big.mark = ",", trim = T), 
+                                                             total_number_of_discharged_patients)),
       style = 'bootstrap', 
       class = 'table_bordered table-condensed',
       rownames = FALSE, 
-      options = list(
-         pageLength = 16, 
-         autoWidth = FALSE, 
-         dom = 'tip'
-      ), 
+      options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+         # Right align numeric columns - it's columns 3:5 but use 2:4 as rownames = FALSE
+         columnDefs = list(list(className = 'dt-right', targets = 2:4))), 
       colnames = c("Health Board", 
                    "Calendar Quarter", 
                    "Number of Patients Followed Up", 
@@ -543,20 +561,31 @@ output$S2_plot3_title <- renderUI({
 
    ## Table for graph 3 ----
    
-   
+  
    output$S2_3_table <- renderDataTable({
       datatable(
          S2_plot3_data_for_table() %>% 
-            # Add "NA" as a value to table on dashboard: 
-            mutate(across(number_of_patients_followed_up:percentage_followed_up, ~replace(., is.na(.), "NA"))),, 
+           # Add "NA" as a value to table on dashboard:
+           mutate(across(number_of_patients_followed_up:total_number_of_discharged_patients, 
+                         ~replace(., is.na(.), "NA"))) %>% 
+           # Add % sign to percentage variable:
+           mutate(percentage_followed_up = if_else(is.na(percentage_followed_up),
+                                                   "NA",
+                                                   paste0(percentage_followed_up, " %"))) %>% 
+           # Add commas to large values but keep "NA" or "*" character values (values are all currenlty under 1000 so don't need this yet):
+           mutate(total_number_of_discharged_patients = if_else(!grepl("\\D", total_number_of_discharged_patients), 
+                                                                format(as.numeric(total_number_of_discharged_patients), 
+                                                                       big.mark = ",", trim = T), 
+                                                                total_number_of_discharged_patients)),
          style = 'bootstrap', 
          class = 'table_bordered table-condensed',
          rownames = FALSE, 
          options = list(
             pageLength = 16, 
             autoWidth = FALSE, 
-            dom = 'tip'
-         ), 
+            dom = 'tip', 
+            # Right align numeric columns - it's columns 3:5 but use 2:4 as rownames = FALSE
+            columnDefs = list(list(className = 'dt-right', targets = 2:4))), 
          colnames = c("Health Board", 
                       "Calendar Quarter",
                       "Number of Patients Followed Up", 

--- a/modules/indicators/S5_server.R
+++ b/modules/indicators/S5_server.R
@@ -157,13 +157,24 @@ output$S5_trendPlot <- renderPlotly({
 ## Table below graph 1 ----
 
 output$S5_1_table <- renderDataTable({
-   datatable(S5_trendPlot_data()%>% 
+   datatable(S5_trendPlot_data() %>% 
                 # Add "NA" as a value to table on dashboard:
-                mutate(across(number_of_incidents:incidents_per_1000_bed_days, ~replace(., is.na(.), "NA"))),
+               mutate(across(number_of_incidents:incidents_per_1000_bed_days, ~replace(., is.na(.), "NA"))) %>% 
+               # Add commas to large values but keep "NA" or "*" character values:
+               mutate(total_occupied_psychiatric_bed_days = if_else(!grepl("\\D", total_occupied_psychiatric_bed_days), 
+                                                                             format(as.numeric(total_occupied_psychiatric_bed_days), 
+                                                                                    big.mark = ",", trim = T), 
+                                                                    total_occupied_psychiatric_bed_days), 
+                      number_of_incidents = if_else(!grepl("\\D", number_of_incidents),
+                                                    format(as.numeric(number_of_incidents), 
+                                                           big.mark = ",", trim = T), 
+                                                    number_of_incidents)),
              style = 'bootstrap',
              class = 'table-bordered table-condensed',
              rownames = FALSE,
-             options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip'),
+             options = list(pageLength = 16, autoWidth = FALSE, dom = 'tip', 
+                            # Right align numeric columns - it's columns 3:5 but use 2:4 as rownames = FALSE
+                            columnDefs = list(list(className = 'dt-right', targets = 2:4))), 
              colnames = c("NHS Health Board",
                           "Calendar Quarter",
                           "Number of Incidents", 
@@ -324,15 +335,25 @@ output$S5_2_table <- renderDataTable({
    datatable(
       S5_plot2_data_for_table() %>% 
          # Add "NA" as a value to table on dashboard:
-         mutate(across(number_of_incidents:incidents_per_1000_bed_days, ~replace(., is.na(.), "NA"))),
+         mutate(across(number_of_incidents:incidents_per_1000_bed_days, ~replace(., is.na(.), "NA"))) %>% 
+        # Add commas to large values but keep "NA" or "*" character values:
+        mutate(total_occupied_psychiatric_bed_days = if_else(!grepl("\\D", total_occupied_psychiatric_bed_days), 
+                                                             format(as.numeric(total_occupied_psychiatric_bed_days), 
+                                                                    big.mark = ",", trim = T), 
+                                                             total_occupied_psychiatric_bed_days), 
+               number_of_incidents = if_else(!grepl("\\D", number_of_incidents),
+                                             format(as.numeric(number_of_incidents), 
+                                                    big.mark = ",", trim = T), 
+                                             number_of_incidents)),
       style = 'bootstrap', 
       class = 'table_bordered table-condensed',
       rownames = FALSE, 
       options = list(
          pageLength = 16, 
          autoWidth = FALSE, 
-         dom = 'tip'
-      ), 
+         dom = 'tip', 
+         # Right align numeric columns - it's columns 3:5 but use 2:4 as rownames = FALSE
+         columnDefs = list(list(className = 'dt-right', targets = 2:4))),
       colnames = c("NHS Health Board",
                    "Calendar Quarter",
                    "Number of Incidents", 


### PR DESCRIPTION
S1, S2, EF4, E1, EF4, and EQ1 (indicators with graphs and tables)
- All tables now show a % if percentage is mentioned/ selected
- All tables have their numeric variables right aligned 
- All tables show "NA" where appropriate 
- All tables have commas separating large numbers (different techniques for different variables as sometimes we need to keep character values such as "*" for supressed figures)