### PR TITLE
Link edits for screen readers

### DIFF
--- a/modules/indicators/EF1_ui.R
+++ b/modules/indicators/EF1_ui.R
@@ -36,7 +36,7 @@ tabItem(tabName = "EF1_tab",
                   SMR records in recent years can be found ", 
                   a(href = "https://www.opendata.nhs.scot/dataset/scottish-morbidity-record-completeness", 
                     target = "_blank",
-                    "here.")),
+                    "on the Public Health Scotland SMR Completeness open data web page.")),
                 p("Next update: July 2026")
             )
           ),  

--- a/modules/indicators/EF2_ui.R
+++ b/modules/indicators/EF2_ui.R
@@ -36,7 +36,7 @@ tabItem(tabName = "EF2_tab",
                   SMR records in recent years can be found ", 
                   a(href = "https://www.opendata.nhs.scot/dataset/scottish-morbidity-record-completeness", 
                     target = "_blank",
-                    "here.")),
+                    "on the Public Health Scotland SMR Completeness open data web page.")),
                 p("Next update: July 2026")
             )
           ),  

--- a/modules/indicators/EF3_ui.R
+++ b/modules/indicators/EF3_ui.R
@@ -50,9 +50,8 @@ tabItem(tabName = "EF3_tab",
                 p("NHS Board level data is available from the ",
                   a(href = "https://www.publichealthscotland.scot/resources-and-tools/medical-practice-and-pharmaceuticals/discovery/overview/what-is-discovery/", 
                     target = "_blank", 
-                    "Discovery"), 
-                  " online management information system to health and social care 
-                  staff from organisation across Scotland including: Scottish 
+                    "Discovery online management information system"), 
+                  " to health and social care staff from organisation across Scotland including: Scottish 
                   Government, territorial and special health boards, local authorities 
                   and health and social care partnerships. Discovery is not open 
                   to members of the public, the press, academia, or researchers."),

--- a/modules/indicators/EQ4_ui.R
+++ b/modules/indicators/EQ4_ui.R
@@ -36,8 +36,8 @@ tabItem(tabName = "EQ4_tab",
               SMR records in recent years can be found ", 
               a(href = "https://www.opendata.nhs.scot/dataset/scottish-morbidity-record-completeness", 
                 target = "_blank",
-                "here.")),
-            # CHECK THIS
+                "on the Public Health Scotland SMR Completeness open data web page.")),
+            # CHECK THIS - it was added to the Nov 2024 pdf publication:
             # p("Specialist CAMHS wards are defined as admissions to specialty G2, 
             #   Child and Adolescent psychiatry at either Royal Hospital for Children 
             #   (NHS Greater Glasgow & Clyde), Skye House (NHS Greater Glasgow & Clyde), 


### PR DESCRIPTION
Expanding the text that external links cover so that full descriptions of the links are included when using a screen reader - EF1, EF2, EF3, EQ4