### PR TITLE
fix(ui): reset scroll position to top on tab change

### DIFF
--- a/app.R
+++ b/app.R
@@ -58,7 +58,15 @@ ui <-
     source("www/dashboard_style.R", local = TRUE)$value,
     
     ## load css stylesheet that defines how things look 
-    tags$head(includeCSS("www/stylesheet.css")),
+    tags$head(includeCSS("www/stylesheet.css"),
+  
+      # JS to ensure the page resets to the top when switching between tabs
+      tags$script(HTML("
+          $(document).on('shown.bs.tab', function () {
+            window.scrollTo(0, 0);
+          });
+        "))             
+    ),
     
     ## Tabs ----
     tabItems(


### PR DESCRIPTION
## Summary
Reset scroll position to the top when switching between dashboard tabs.

## Related Issue
Fixes bug #124.