### PR TITLE
S2, S5 and EF5 HB updates

### DIFF
--- a/modules/indicators/EF5_server.R
+++ b/modules/indicators/EF5_server.R
@@ -112,7 +112,7 @@ output$EF5_trendPlot <- renderPlotly({
                            # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                            # Starting at -0.5 and ending at 11.5 gives much nicer 
                            # spacing on the axis than "0, 12"
-                           range = list(-0.5, 14.5), 
+                           range = list(-0.5, 15.5), 
                            showline = TRUE, 
                            ticks = "outside"),
               

--- a/modules/indicators/EF5_ui.R
+++ b/modules/indicators/EF5_ui.R
@@ -11,7 +11,7 @@ tabItem(tabName = "EF5_tab",
           h1(paste0(
             "EF5 - Percentage (%) of 'Did Not Attend' appointments for community based ",
             "services of people with mental health conditions")),
-          h3("Last Updated: December 2025"),
+          h3("Last Updated: March 2026"),
           
           hr(),       # page break
           
@@ -147,11 +147,11 @@ tabItem(tabName = "EF5_tab",
                         which are submitted quarterly and may be incomplete.
                         Data completeness and performance against an indicator 
                         can vary between boards."), 
-                        p("Board returns for July-September 2025 have been received from: 
-                        NHS Ayrshire & Arran, NHS Borders, NHS Fife, 
-                        NHS Forth Valley, NHS Grampian, 
-                        NHS Highland, NHS Lanarkshire, NHS Orkney, NHS Shetland, 
-                        NHS Tayside and NHS Western Isles."), 
+                        p("Board returns for October-December 2025 have been received from: 
+                        NHS Ayrshire & Arran, NHS Borders, NHS Dumfries & Galloway,
+                        NHS Fife, NHS Forth Valley, NHS Grampian, 
+                        NHS Greater Glasgow & Clyde, NHS Highland, NHS Lanarkshire, 
+                        NHS Lothian, NHS Shetland and NHS Western Isles."), 
                         p("Data for all community mental health outpatient appointments, 
                           all ages and all care groups are requested in the 
                           health board returns. Individual health board data may 
@@ -159,7 +159,7 @@ tabItem(tabName = "EF5_tab",
                           reporting software systems."), 
                         p("All reasons for 'Did Not Attend' are included but not 
                           reported in this indicator."),
-                        p("Next update: April 2026"))
+                        p("Next update: July 2026"))
              )
           ),  
          

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -103,7 +103,7 @@ output$S2_trendPlot <- renderPlotly({
                         # quarter (i.e. it will be (-0.5, 13.5) for October 2025 update)
                         # For July 2025, starting the range at -0.5 and ending at 
                         # 12.5 gives much nicer spacing on the axis than "0, 13"
-                        range = list(-0.5, 14.5), 
+                        range = list(-0.5, 15.5), 
                         showline = TRUE, 
                         ticks = "outside"),
            
@@ -215,7 +215,7 @@ output$S2_plot2_quarter_output <- renderUI({
       "S2_plot2_quarter",
       label = "Select calendar quarter:",
       choices = unique(S2_data$year_months),
-      selected = "Jul-Sep 2025")
+      selected = "Oct-Dec 2025")
 })
 
 ## Selecting appropriate data for graph 2 ---- 

--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -495,7 +495,7 @@ output$S2_plot3_title <- renderUI({
                                 ),
                    
                    xaxis = list(# For range explanation: see same note in Graph 1 xaxis
-                                range = list(-0.5, 14.5), 
+                                range = list(-0.5, 15.5), 
                                 tickangle = -45,    # Diagonal x-axis ticks
                                 title = paste0(c(rep("&nbsp;", 20),
                                                  "<br>",

--- a/modules/indicators/S2_ui.R
+++ b/modules/indicators/S2_ui.R
@@ -16,7 +16,7 @@ tabItem(tabName = "S2_tab",
            h1(paste0(
              "S2 - Percentage (%) of all discharged psychiatric inpatients ",
              "followed up by community mental health services within 7 calendar days")),
-           h3("Last Updated: December 2025"),
+           h3("Last Updated: March 2026"),
            
            hr(),       # page break
            
@@ -224,10 +224,11 @@ tabItem(tabName = "S2_tab",
                  and performance against an indicator can vary between boards."),
                  p("Data for NHS Orkney and NHS Shetland are included in the NHS 
                    Grampian figures."),
-                 p("Board returns for July-September 2025 have been received from: 
-                 NHS Ayrshire & Arran, NHS Borders, NHS Fife, 
-                 NHS Forth Valley, NHS Grampian, 
-                 NHS Highland, NHS Tayside and NHS Western Isles."), 
+                 p("Board returns for October-December 2025 have been received from: 
+                 NHS Ayrshire & Arran, NHS Borders, NHS Dumfries & Galloway,
+                        NHS Fife, NHS Forth Valley, NHS Grampian, 
+                        NHS Greater Glasgow & Clyde, NHS Highland, NHS Lanarkshire, 
+                        NHS Lothian and NHS Western Isles."), 
                  p("Data from all hospital psychiatric inpatient wards and from 
                  all community mental health services of all care groups and 
                  ages is included. The following specialties are included where
@@ -248,7 +249,7 @@ tabItem(tabName = "S2_tab",
                    " states: 'Community Services: This is care and support which 
                    can be accessed without the need to be admitted to an inpatient 
                  hospital ward.'"),
-                 p("Next update: April 2026")
+                 p("Next update: July 2026")
                  )
              )),
                   

--- a/modules/indicators/S5_server.R
+++ b/modules/indicators/S5_server.R
@@ -106,7 +106,7 @@ output$S5_trendPlot <- renderPlotly({
                           # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                           # Starting at -0.5 and ending at 11.5 gives much nicer 
                           # spacing on the axis than "0, 12"
-                          range = list(-0.5, 14.5),
+                          range = list(-0.5, 15.5),
                           showline = TRUE, 
                           ticks = "outside"),
              
@@ -210,7 +210,7 @@ output$S5_plot2_quarter_output <- renderUI({
       "S5_plot2_quarter",
       label = "Select calendar quarter:",
       choices = unique(S5_data$year_months),
-      selected = "Jul-Sep 2025")
+      selected = "Oct-Dec 2025")
 })
 
 ## Selecting appropriate data for graph 2 ---- 

--- a/modules/indicators/S5_ui.R
+++ b/modules/indicators/S5_ui.R
@@ -16,7 +16,7 @@ tabItem(tabName = "S5_tab",
      # Title for S5 tab ----
           
           h1("S5 - Incidents of physical violence per 1,000 occupied psychiatric bed days"),
-          h3("Last Updated: December 2025"),
+          h3("Last Updated: March 2026"),
           
           hr(),       # page break
           
@@ -154,10 +154,11 @@ tabItem(tabName = "S5_tab",
                     quarterly and may be incomplete. Data completeness and performance 
                     against an indicator can vary between boards."),
                  p("Data for NHS Orkney and NHS Shetland are included in the NHS Grampian figures."),
-                 p("Board returns for July-September 2025 have been received from: 
-                 NHS Ayrshire & Arran, NHS Borders, NHS Fife, 
-                 NHS Forth Valley, NHS Grampian, 
-                 NHS Highland, NHS Lanarkshire,  NHS Tayside and NHS Western Isles."), 
+                 p("Board returns for October-December 2025 have been received from: 
+                 NHS Ayrshire & Arran, NHS Borders, NHS Dumfries & Galloway,
+                        NHS Fife, NHS Forth Valley, NHS Grampian, 
+                        NHS Greater Glasgow & Clyde, NHS Highland, NHS Lanarkshire, 
+                        NHS Lothian, NHS Shetland and NHS Western Isles."), 
                  p("To ensure accurate reporting, NHS Dumfries & Galloway data for 
                  Jan-Mar 2025 are not available due to a transition between data 
                  reporting software systems. Future submissions are expected 


### PR DESCRIPTION
S2, S5 and EF5 HB updates: alter server to allow space on chart for oct-dec. S5 and S2: change selected quarter from jul-sep to oct-dec.

S2, S5 and EF5 ui updates: change last updated and next updated date. Update board returns time frame to oct-dec and boards that have submitted. No return from Orkney and Tayside yet. 

