### PR TITLE
148 ef1 ef2 and eq4 updates apr 26

### DIFF
--- a/data_preparation.R
+++ b/data_preparation.R
@@ -191,7 +191,7 @@ EF2_data <- EF2 |>
                                    "Jan-Mar 2024", "Apr-Jun 2024",
                                    "Jul-Sep 2024", "Oct-Dec 2024",
                                    "Jan-Mar 2025", "Apr-Jun 2025",
-                                   "Jul-Sep 2025")))
+                                   "Jul-Sep 2025", "Oct-Dec 2025")))
 
 EF2_hb_names <- EF2 %>%
   distinct(Board) %>% pull(Board)

--- a/data_preparation.R
+++ b/data_preparation.R
@@ -127,7 +127,7 @@ EF1_data <- readxl::read_xlsx("data/EF1_Excel.xlsx") %>%
   mutate(months = case_when(
     month %in% c("04", "05", "06") ~ "Apr-Jun",
     month %in% c("07", "08", "09") ~ "Jul-Sep",
-    month %in% 10:12 ~ "Oct-Dec",
+    month %in% c("10", "11", "12") ~ "Oct-Dec",
     month %in% c("01", "02", "03") ~ "Jan-Mar")) |> 
   #unite year and month column for analysis
   unite(year_months, c (months, year), sep = " ", remove = FALSE) |> 
@@ -160,7 +160,7 @@ EF2 <- read_excel(
   mutate(months = case_when(
     month %in% c("04", "05", "06") ~ "Apr-Jun",
     month %in% c("07", "08", "09") ~ "Jul-Sep",
-    month %in% 10:12 ~ "Oct-Dec",
+    month %in% c("10", "11", "12") ~ "Oct-Dec",
     month %in% c("01", "02", "03") ~ "Jan-Mar")) |> 
   #unite year and month column for analysis
 unite(year_months, c (months, year), sep = " ", remove = FALSE) |> 
@@ -311,7 +311,7 @@ eq4_tidy <- eq4 |>
   mutate(discharge_quarter = case_when(
     month %in% c("04", "05", "06") ~ "Q1",
     month %in% c("07", "08", "09") ~ "Q2",
-    month %in% 10:12 ~ "Q3",
+    month %in% c("10", "11", "12") ~ "Q3",
     month %in% c("01", "02", "03") ~ "Q4")) |> 
   # Create financial year column
   # financial year

--- a/data_preparation.R
+++ b/data_preparation.R
@@ -118,30 +118,19 @@ EF1_data <- readxl::read_xlsx("data/EF1_Excel.xlsx") %>%
   # Select and rename necessary columns
   select(Board, 'Month of Discharge', 'Bed day rate') %>% 
   rename(hb_name = Board,
-         month = "Month of Discharge",
          bedday_rate = "Bed day rate") %>% 
   # Fill in missing health board names
   fill(hb_name, .direction = "down") %>%
   # Produce quarters
-  mutate(
-    year_months = recode(month,
-                         'January 2022' = 'Jan-Mar 2022', 'February 2022' = 'Jan-Mar 2022', 'March 2022' = 'Jan-Mar 2022',
-                         'April 2022' = 'Apr-Jun 2022', 'May 2022' = 'Apr-Jun 2022', 'June 2022' = 'Apr-Jun 2022',
-                         'July 2022' = 'Jul-Sep 2022', 'August 2022' = 'Jul-Sep 2022', 'September 2022' = 'Jul-Sep 2022',
-                         'October 2022' = 'Oct-Dec 2022', 'November 2022' = 'Oct-Dec 2022', 'December 2022' = 'Oct-Dec 2022',
-                         'January 2023' = 'Jan-Mar 2023', 'February 2023' = 'Jan-Mar 2023', 'March 2023' = 'Jan-Mar 2023',
-                         'April 2023' = 'Apr-Jun 2023', 'May 2023' = 'Apr-Jun 2023', 'June 2023' = 'Apr-Jun 2023',
-                         'July 2023' = 'Jul-Sep 2023', 'August 2023' = 'Jul-Sep 2023', 'September 2023' = 'Jul-Sep 2023',
-                         'October 2023' = 'Oct-Dec 2023', 'November 2023' = 'Oct-Dec 2023', 'December 2023' = 'Oct-Dec 2023',
-                         'January 2024' = 'Jan-Mar 2024', 'February 2024' = 'Jan-Mar 2024', 'March 2024' = 'Jan-Mar 2024',
-                         'April 2024' = 'Apr-Jun 2024', 'May 2024' = 'Apr-Jun 2024', 'June 2024' = 'Apr-Jun 2024',
-                         'July 2024' = 'Jul-Sep 2024', 'August 2024' = 'Jul-Sep 2024', 'September 2024' = 'Jul-Sep 2024',
-                         'October 2024' = 'Oct-Dec 2024', 'November 2024' = 'Oct-Dec 2024', 'December 2024' = 'Oct-Dec 2024',
-                         'January 2025' = 'Jan-Mar 2025', 'February 2025' = 'Jan-Mar 2025', 'March 2025' = 'Jan-Mar 2025',
-                         'April 2025' = 'Apr-Jun 2025', 'May 2025' = 'Apr-Jun 2025', 'June 2025' = 'Apr-Jun 2025',
-                         'July 2025' = 'Jul-Sep 2025', 'August 2025' = 'Jul-Sep 2025', 'September 2025' = 'Jul-Sep 2025',
-                         'October 2025' = 'Oct-Dec 2025', 'November 2025' = 'Oct-Dec 2025', 'December 2025' = 'Oct-Dec 2025'
-    )) %>% 
+  #year and month column
+  separate(`Month of Discharge`, into = c("year", "month"), sep = "-", remove = FALSE) |> 
+  mutate(months = case_when(
+    month %in% c("04", "05", "06") ~ "Apr-Jun",
+    month %in% c("07", "08", "09") ~ "Jul-Sep",
+    month %in% 10:12 ~ "Oct-Dec",
+    month %in% c("01", "02", "03") ~ "Jan-Mar")) |> 
+  #unite year and month column for analysis
+  unite(year_months, c (months, year), sep = " ", remove = FALSE) |> 
   mutate(hb_name = if_else(hb_name == "Scotland", 
                            "NHS Scotland", hb_name)) %>%
   # Using months in order function to factor relevel the year_months variable
@@ -151,10 +140,7 @@ EF1_data <- readxl::read_xlsx("data/EF1_Excel.xlsx") %>%
   summarise(bedday_rate = sum(bedday_rate)) %>% 
   # Round bed day rate to two decimal places
   mutate(bedday_rate = round(bedday_rate, digits = 2)) %>%
-  ungroup() %>% 
-  # Filter out data beyond Jul-Sep
-  filter(year_months != "Oct-Dec 2025") #%>% 
-#filter(hb_name != "Scotland")
+  ungroup() 
 
 EF1_hb_names <- EF1_data %>% 
   distinct(hb_name) %>% pull(hb_name)
@@ -185,7 +171,9 @@ unite(year_months, c (months, year), sep = " ", remove = FALSE) |>
   ungroup() %>% 
   mutate(x28_days_readmission_rate_percentage_quarter = round((total_readmissions_quarter / total_admissions_quarter) * 100, 1)) |> 
   mutate(Board = recode(Board,
-         "Scotland" = "NHS Scotland"))
+         "Scotland" = "NHS Scotland")) |> 
+  #replace NaN NHS Shetland calc with 0
+  mutate(across(where(is.numeric), ~ replace(., is.nan(.), 0)))
  
 
 EF2_data <- EF2 |>
@@ -362,7 +350,8 @@ EQ4_data <- eq4_tidy %>%
                                  "Q3 2023/2024", "Q4 2023/2024",
                                  "Q1 2024/2025", "Q2 2024/2025",
                                  "Q3 2024/2025", "Q4 2024/2025",
-                                 "Q1 2025/2026", "Q2 2025/2026"))) 
+                                 "Q1 2025/2026", "Q2 2025/2026",
+                                 "Q3 2025/2026"))) 
 
 EQ4_hb_names <- eq4 %>% 
   distinct(board) %>% pull(board)

--- a/modules/indicators/EF1_server.R
+++ b/modules/indicators/EF1_server.R
@@ -105,7 +105,7 @@ output$EF1_trendPlot <- renderPlotly({
                    # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                    # Starting at -0.5 and ending at 11.5 gives much nicer 
                    # spacing on the axis than "0, 12"
-                   range = list(-0.5, 13.5),
+                   range = list(-0.5, 14.5),
                    showline = TRUE, 
                    ticks = "outside"),
       
@@ -191,7 +191,7 @@ output$EF1_plot2_quarter_output <- renderUI({
     "EF1_plot2_quarter",
     label = "Select calendar quarter:",
     choices = unique(EF1_data$year_months),
-    selected = "Jul-Sep 2025")
+    selected = "Oct-Dec 2025")
 })
 
 ## Selecting appropriate data for graph 2 ---- 

--- a/modules/indicators/EF1_ui.R
+++ b/modules/indicators/EF1_ui.R
@@ -16,7 +16,7 @@ tabItem(tabName = "EF1_tab",
           # Title for EF1 tab ----
           
           h1("EF1 - Rate of emergency bed days for adults in psychiatric hospital beds"),
-          h3("Last Updated: January 2026"),
+          h3("Last Updated: March 2026"),
           
           hr(),       # page break
           
@@ -156,14 +156,14 @@ tabItem(tabName = "EF1_tab",
                   authorities and health and social care partnerships. Discovery 
                   is not open to members of the public, the press, academia, or 
                   researchers. At time of data extraction data completeness was unavailable for State Hospital (due to issues with their system)
-                  and was below 90% for NHS Grampian and NHS Highland. Data completeness 
-                  for Scotland overall at the time of data extraction was 97%, well above the NHS Scotland 90% threshold for 
+                  and was below 90% for NHS Dumfries & Galloway, NHS Grampian and NHS Highland. Data completeness 
+                  for Scotland overall at the time of data extraction was 95%, well above the NHS Scotland 90% threshold for 
                   publications. Estimates of completeness of 
                   SMR records in recent years can be found ", 
                   a(href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/", 
                     target = "_blank",
                     "on the Public Health Scotland SMR Completeness open data web page.",),
-                p("Next update: April 2026")
+                p("Next update: July 2026")
             )
           ), 
           

--- a/modules/indicators/EF2_server.R
+++ b/modules/indicators/EF2_server.R
@@ -99,7 +99,7 @@ output$EF2_trendPlot <- renderPlotly({
                    # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                    # Starting at -0.5 and ending at 11.5 gives much nicer 
                    # spacing on the axis than "0, 12"
-                   range = list(-0.5, 15.5),
+                   range = list(-0.5, 14.5),
                    showline = TRUE, 
                    ticks = "outside"),
       
@@ -183,7 +183,7 @@ output$EF2_plot2_quarter_output <- renderUI({
     "EF2_plot2_quarter",
     label = "Select calendar quarter:",
     choices = unique(EF2_data$year_months),
-    selected = "Jul-Sep 2025")
+    selected = "Oct-Dec 2025")
 })
 
 ## Selecting appropriate data for graph 2 ---- 

--- a/modules/indicators/EF2_ui.R
+++ b/modules/indicators/EF2_ui.R
@@ -3,7 +3,7 @@ tabItem(tabName = "EF2_tab",
           ## Title section ----
           h1(paste0(
             "EF2 - Mental health emergency readmissions to hospital within 28 days of discharge")),
-          h3("Last Updated: November 2025"),
+          h3("Last Updated: March 2026"),
           
           hr(),       # page break
           
@@ -154,14 +154,14 @@ tabItem(tabName = "EF2_tab",
                   authorities and health and social care partnerships. Discovery 
                   is not open to members of the public, the press, academia, or 
                   researchers. At time of data extraction data completeness was unavailable for State Hospital (due to issues with their system)
-                  and was below 90% for NHS Grampian and NHS Highland. Data completeness 
-                  for Scotland overall at the time of data extraction was 97%, well above the NHS Scotland 90% threshold for 
+                  and was below 90% for NHS Dumfries & Galloway, NHS Grampian and NHS Highland. Data completeness 
+                  for Scotland overall at the time of data extraction was 95%, well above the NHS Scotland 90% threshold for 
                   publications. Estimates of completeness of 
                   SMR records in recent years can be found ", 
                     a(href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/", 
                       target = "_blank",
                       "on the Public Health Scotland SMR Completeness open data web page.",),
-                  p("Next update: April 2026")
+                  p("Next update: July 2026")
               )
             ),  
             

--- a/modules/indicators/EQ4_server.R
+++ b/modules/indicators/EQ4_server.R
@@ -98,7 +98,7 @@ output$EQ4_trendPlot <- renderPlotly({
                    # quarter (i.e. it will be (-0.5, 12.5) for July 2025 update)
                    # Starting at -0.5 and ending at 11.5 gives much nicer 
                    # spacing on the axis than "0, 12"
-                   range = list(-0.5, 15.5),
+                   range = list(-0.5, 14.5),
                    showline = TRUE, 
                    ticks = "outside"),
       

--- a/modules/indicators/EQ4_ui.R
+++ b/modules/indicators/EQ4_ui.R
@@ -3,7 +3,7 @@ tabItem(tabName = "EQ4_tab",
           ## Title section ----
           h1(paste0(
             "EQ4 - % of under 18 year old psychiatric admissions admitted outwith NHS specialist Child and Adolescent Mental Health (CAMH) wards")),
-          h3("Last Updated: January 2026"),
+          h3("Last Updated: March 2026"),
           
           hr(),       # page break
           
@@ -94,8 +94,8 @@ tabItem(tabName = "EQ4_tab",
               not open to members of the public, the press, academia, or 
               researchers. 
               At time of data extraction data completeness was unavailable for State Hospital (due to issues with their system)
-                  and was below 90% for NHS Grampian and NHS Highland. Data completeness 
-                  for Scotland overall at the time of data extraction was 97%, well above the NHS Scotland 90% threshold for 
+                  and was below 90% for NHS Dumfries & Galloway, NHS Grampian and NHS Highland. Data completeness 
+                  for Scotland overall at the time of data extraction was 95%, well above the NHS Scotland 90% threshold for 
                   publications. Estimates of completeness of 
                   SMR records in recent years can be found ", 
                   a(href = "https://publichealthscotland.scot/resources-and-tools/health-intelligence-and-data-management/data-management-in-secondary-care-hospital-activity/scottish-morbidity-records-smr/completeness/", 
@@ -122,7 +122,7 @@ tabItem(tabName = "EQ4_tab",
                 # House, those admitted from 1 January 2018 with the Stobhill hospital code 
                 # to child and adolescent psychiatry, child psychiatry or adolescent 
                 # psychiatry were assumed to be in Skye House."),
-                p("Next update: April 2026")   
+                p("Next update: July 2026")   
             )
           ),  
           


### PR DESCRIPTION
Data Prep Script
EF1:- altered code Cormac previously completed. The March 2026 EF1 download now named months differently (Oct-25 instead of October 2025). Changed code to prevent changning this each time if months are renamed differently again.
- removed code to filter out data beyond jul-sep.

EF2:- added code to change NaN (not a number) result from calculation to 0. This was to alter NHS Shetland results which had no readmissions or admissions.
- add oct-dec into year_months column factor relevel.

EQ4:- add quarter and financial year to quarter_fy factor relevel.

Server scripts: update chart to include oct-dec figure and change selected date to Oct-Dec 2025.

UI scripts: update last updated and next updated date. Update data completeness information for this quarter.