### PR TITLE
174 s2 corrections for april publication

### DIFF
--- a/modules/indicators/S2_server.R
+++ b/modules/indicators/S2_server.R
@@ -93,7 +93,7 @@ output$S2_trendPlot <- renderPlotly({
                         title = paste0(c(rep("&nbsp;", 20),
                                          "<br>",
                                          "<br>",
-                                         "Calendar Year",
+                                         "Calendar quarter",
                                          rep("&nbsp;", 20),
                                          rep("\n&nbsp;", 3)),
                                        collapse = ""),

--- a/modules/indicators/S2_ui.R
+++ b/modules/indicators/S2_ui.R
@@ -227,7 +227,7 @@ tabItem(tabName = "S2_tab",
                  p("Board returns for October-December 2025 have been received from: 
                  NHS Ayrshire & Arran, NHS Borders, NHS Dumfries & Galloway,
                         NHS Fife, NHS Forth Valley, NHS Grampian, 
-                        NHS Greater Glasgow & Clyde, NHS Highland, NHS Lanarkshire, 
+                        NHS Greater Glasgow & Clyde, NHS Highland, 
                         NHS Lothian, NHS Tayside and NHS Western Isles."), 
                  p("Data from all hospital psychiatric inpatient wards and from 
                  all community mental health services of all care groups and 


### PR DESCRIPTION
Hi Lauren,

I spotted a couple of minor things in S2 to correct - one x-axis label for the first chart (calendar quarter instead of calendar year) and also I deleted 'NHS Lanarkshire' from the text at the bottom of the indicator since it seems like they don't have any data at all for S2. Thanks in advance for checking these changes! We can redeploy at some point on Monday once you've approved.

James