### PR TITLE
E1 data update

### DIFF
--- a/data_preparation.R
+++ b/data_preparation.R
@@ -104,8 +104,7 @@ E1_data <- read.csv("data/E1.csv") %>%
    mutate(fyear = factor(fyear, levels = 
                             c("2016/17", "2017/18", "2018/19", 
                               "2019/20", "2020/21", "2021/22", 
-                              "2022/23", "2023/24", "2024/25"))) %>% 
-                              # , "2025/26")))
+                              "2022/23", "2023/24", "2024/25", "2025/26"))) %>% 
    arrange(fyear, area_type, status, area_name) %>% 
   select(-status)
 

--- a/modules/indicators/E1_server.R
+++ b/modules/indicators/E1_server.R
@@ -240,7 +240,7 @@ output$E1_plot2_year_output <- renderUI({
       "E1_plot2_year",
       label = "Select financial year:",
       choices = E1_fyear,
-      selected = "2024/25")
+      selected = "2025/26")
 })
 
 ## Selecting appropriate data for graph 2 ---- 

--- a/modules/indicators/E1_ui.R
+++ b/modules/indicators/E1_ui.R
@@ -18,7 +18,7 @@ tabItem(tabName = "E1_tab",
           h1("E1 - Delayed Discharges: Number of days people spend in hospital 
              within mental health specialties when they are clinically ready to be 
              discharged (per 1,000 population)"),
-          h3("Last Updated: January 2026"),
+          h3("Last Updated: July 2026"),
           
           
           hr(),     # page break 
@@ -154,10 +154,10 @@ tabItem(tabName = "E1_tab",
                         days by specialty is sourced and published in data tables 
                         by Public Health Scotland (PHS) as part of the ",
                           a("delayed discharges in NHS Scotland annual publication,",
-                            href="https://publichealthscotland.scot/publications/delayed-discharges-in-nhsscotland-annual/delayed-discharges-in-nhsscotland-annual-annual-summary-of-occupied-bed-days-and-census-figures-data-to-march-2025/",
+                            href="https://publichealthscotland.scot/publications/delayed-discharges-in-nhs-scotland-annual/delayed-discharges-in-nhs-scotland-annual-summary-of-occupied-bed-days-and-census-figures-data-to-march-2026/",
                             target = "_blank"),
                           " which covers a summary of occupied bed days and census 
-                          figures up to March 2025."),
+                          figures up to March 2026."),
                         p("Mid-year population estimates time series data comes 
                           from the ",
                           a("National Records of Scotland", 
@@ -165,7 +165,8 @@ tabItem(tabName = "E1_tab",
                            # href="https://www.nrscotland.gov.uk/statistics-and-data/statistics/statistics-by-theme/population/population-estimates/mid-year-population-estimates/population-estimates-time-series-data",
                            href = "https://www.nrscotland.gov.uk/publications/population-estimates-time-series-data/",
                             target = "_blank"), 
-                          " website. This publication release features updated population estimates for 2024/25."), 
+                          " website. For this publication,  the population estimates for 
+                          financial year 2025/26 have not been released yet and so they are copied from 2024/25."), 
                         p("Figures prior to July 2016 are not comparable with the 
                           figures from July 2016 onwards due to revised data 
                           definitions and national data requirements which were 
@@ -179,10 +180,12 @@ tabItem(tabName = "E1_tab",
                         covered in the ", 
                           a("delayed discharges in NHS Scotland annual publication.",
                             href="https://publichealthscotland.scot/publications/delayed-discharges-in-nhsscotland-annual/delayed-discharges-in-nhsscotland-annual-annual-summary-of-occupied-bed-days-and-census-figures-data-to-march-2025/",
-                            target = "_blank"))
+                            target = "_blank")),
+                        p("Next update: January 2027")
                         )
              
           )),
+    
           
           br(), 
 

--- a/modules/sidebar_ui.R
+++ b/modules/sidebar_ui.R
@@ -47,7 +47,8 @@ sidebarMenu(
   br(),
   ## Effective Tabs ----           
   menuItem("Effective :"),
-  menuItem("E1 - Delayed Discharge", tabName = "E1_tab", icon = icon("bar-chart")),
+  menuItem("E1 - Delayed Discharge", tabName = "E1_tab", icon = icon("bar-chart"),
+           badgeLabel = "Updated", badgeColor = "orange"),
           
   br(),
   ## Efficient Tabs ----           


### PR DESCRIPTION
E1 updates:
data prep - uncomment 2025/26
ui - update last and next updated dates, update link and figures up to march 26. Add note about population estimates not being available yet for 2025/26.